### PR TITLE
ADR-1455 fix spirits navigation

### DIFF
--- a/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
+++ b/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
@@ -16,20 +16,18 @@
 
 package controllers.spiritsQuestions
 
+import connectors.UserAnswersConnector
 import controllers.actions._
 import forms.spiritsQuestions.DeclareQuarterlySpiritsFormProvider
-
-import javax.inject.Inject
 import models.{Mode, UserAnswers}
 import navigation.QuarterlySpiritsQuestionsNavigator
-import pages.spiritsQuestions.{AlcoholUsedPage, DeclareQuarterlySpiritsPage, DeclareSpiritsTotalPage, EthyleneGasOrMolassesUsedPage, GrainsUsedPage, OtherIngredientsUsedPage, OtherMaltedGrainsPage, SpiritTypePage, WhiskyPage}
+import pages.spiritsQuestions._
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
-import connectors.UserAnswersConnector
-import models.spiritsQuestions.EthyleneGasOrMolassesUsed
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.spiritsQuestions.DeclareQuarterlySpiritsView
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 

--- a/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
+++ b/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
@@ -78,7 +78,7 @@ class DeclareQuarterlySpiritsController @Inject() (
           )
       }
 
-  def clearUserAnswersWhenNoSelectedAfterYes(userAnswer: UserAnswers, value: Boolean): Try[UserAnswers] =
+  private def clearUserAnswersWhenNoSelectedAfterYes(userAnswer: UserAnswers, value: Boolean): Try[UserAnswers] =
     if (value) {
       Try(userAnswer)
     } else {

--- a/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
+++ b/app/controllers/spiritsQuestions/DeclareQuarterlySpiritsController.scala
@@ -73,7 +73,7 @@ class DeclareQuarterlySpiritsController @Inject() (
               for {
                 updatedAnswers      <- Future.fromTry(request.userAnswers.set(DeclareQuarterlySpiritsPage, value))
                 maybeClearedAnswers <- Future.fromTry(clearUserAnswersWhenNoSelectedAfterYes(updatedAnswers, value))
-                _                   <- userAnswersConnector.set(updatedAnswers)
+                _                   <- userAnswersConnector.set(maybeClearedAnswers)
               } yield Redirect(navigator.nextPage(DeclareQuarterlySpiritsPage, mode, updatedAnswers))
           )
       }
@@ -85,7 +85,6 @@ class DeclareQuarterlySpiritsController @Inject() (
       userAnswer.remove(
         List(
           AlcoholUsedPage,
-          DeclareQuarterlySpiritsPage,
           DeclareSpiritsTotalPage,
           EthyleneGasOrMolassesUsedPage,
           GrainsUsedPage,

--- a/app/navigation/QuarterlySpiritsQuestionsNavigator.scala
+++ b/app/navigation/QuarterlySpiritsQuestionsNavigator.scala
@@ -62,13 +62,12 @@ class QuarterlySpiritsQuestionsNavigator @Inject() () {
     case _                                                    => controllers.spiritsQuestions.routes.CheckYourAnswersController.onPageLoad()
   }
 
-  private def checkDeclareQuarterlySpiritsNavigation(userAnswers: UserAnswers): Call = {
+  private def checkDeclareQuarterlySpiritsNavigation(userAnswers: UserAnswers): Call =
     userAnswers.get(DeclareQuarterlySpiritsPage) match {
-      case Some(true) => controllers.spiritsQuestions.routes.DeclareSpiritsTotalController.onPageLoad(NormalMode)
+      case Some(true)  => controllers.spiritsQuestions.routes.DeclareSpiritsTotalController.onPageLoad(NormalMode)
       case Some(false) => routes.TaskListController.onPageLoad
-      case None => routes.JourneyRecoveryController.onPageLoad()
+      case None        => routes.JourneyRecoveryController.onPageLoad()
     }
-  }
 
   private def declareQuarterlySpiritsRoute(userAnswers: UserAnswers): Call =
     userAnswers.get(DeclareQuarterlySpiritsPage) match {

--- a/app/navigation/QuarterlySpiritsQuestionsNavigator.scala
+++ b/app/navigation/QuarterlySpiritsQuestionsNavigator.scala
@@ -25,7 +25,7 @@ import play.api.mvc.Call
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class QuarterlySpiritsQuestionsNavigator @Inject() {
+class QuarterlySpiritsQuestionsNavigator @Inject() () {
 
   private val normalRoutes: Page => UserAnswers => Call = {
     case pages.spiritsQuestions.DeclareQuarterlySpiritsPage   => declareQuarterlySpiritsRoute
@@ -48,7 +48,8 @@ class QuarterlySpiritsQuestionsNavigator @Inject() {
 
   }
 
-  private def checkRouteMap(page: Page, hasChanged: Boolean): Call = page match {
+  private def checkRouteMap(page: Page, hasChanged: Boolean, userAnswers: UserAnswers): Call = page match {
+    case pages.spiritsQuestions.DeclareQuarterlySpiritsPage   => checkDeclareQuarterlySpiritsNavigation(userAnswers)
     case pages.spiritsQuestions.SpiritTypePage                =>
       if (hasChanged) controllers.spiritsQuestions.routes.OtherSpiritsProducedController.onPageLoad(CheckMode)
       else controllers.spiritsQuestions.routes.CheckYourAnswersController.onPageLoad()
@@ -59,6 +60,14 @@ class QuarterlySpiritsQuestionsNavigator @Inject() {
       if (hasChanged) controllers.spiritsQuestions.routes.OtherIngredientsUsedController.onPageLoad(CheckMode)
       else controllers.spiritsQuestions.routes.CheckYourAnswersController.onPageLoad()
     case _                                                    => controllers.spiritsQuestions.routes.CheckYourAnswersController.onPageLoad()
+  }
+
+  private def checkDeclareQuarterlySpiritsNavigation(userAnswers: UserAnswers): Call = {
+    userAnswers.get(DeclareQuarterlySpiritsPage) match {
+      case Some(true) => controllers.spiritsQuestions.routes.DeclareSpiritsTotalController.onPageLoad(NormalMode)
+      case Some(false) => routes.TaskListController.onPageLoad
+      case None => routes.JourneyRecoveryController.onPageLoad()
+    }
   }
 
   private def declareQuarterlySpiritsRoute(userAnswers: UserAnswers): Call =
@@ -97,6 +106,6 @@ class QuarterlySpiritsQuestionsNavigator @Inject() {
     case NormalMode =>
       normalRoutes(page)(userAnswers)
     case CheckMode  =>
-      checkRouteMap(page, hasAnswerChanged)
+      checkRouteMap(page, hasAnswerChanged, userAnswers)
   }
 }


### PR DESCRIPTION
There was a bug where the declare quarterly spirits page would error out when selecting a new option for Yes/No (AKA in change mode). I fixed this by using User Answers to decide where to redirect to based on the current answer to the question