### PR TITLE
ADR 1478 add class and method to loggers

### DIFF
--- a/app/controllers/BeforeStartReturnController.scala
+++ b/app/controllers/BeforeStartReturnController.scala
@@ -93,7 +93,7 @@ class BeforeStartReturnController @Inject() (
             auditReturnStarted(userAnswer)
             Redirect(controllers.routes.TaskListController.onPageLoad)
           case Left(error)       =>
-            logger.warn(s"Unable to create userAnswers:", error)
+            logger.warn(s"Unable to create userAnswers: $error")
             Redirect(controllers.routes.JourneyRecoveryController.onPageLoad())
         }
     }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,13 +4,13 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/new_service.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0} %M:%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%class{0}|%caller{0}|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 
@@ -47,6 +47,7 @@
 
     <logger name="org.jboss" level="INFO"/>
     <logger name="io.netty" level="INFO"/>
+
     <logger name="sun.net.www.protocol.http" level="INFO"/>
 
     <logger name="org.mongodb.driver" level="INFO"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -10,7 +10,6 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <includeCallerData>true</includeCallerData>
             <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%class{0}|%M|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -4,13 +4,14 @@
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>logs/new_service.log</file>
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0} %M:%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0}|%M|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%class{0}|%caller{0}|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <includeCallerData>true</includeCallerData>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] rid=[%X{X-Request-ID}] user=[%X{Authorization}] message=[%class{0}|%M|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
 

--- a/it/test/resources/logback.xml
+++ b/it/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-      <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[[%class{0}][%M:%line] - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+      <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0}|%M|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
     </encoder>
   </appender>
   <root level="OFF">

--- a/it/test/resources/logback.xml
+++ b/it/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
   <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
     <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-      <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+      <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[[%class{0}][%M:%line] - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
     </encoder>
   </appender>
   <root level="OFF">

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0}#%M:%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
     <root level="OFF">

--- a/test/resources/logback.xml
+++ b/test/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
-            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0}#%M:%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
+            <pattern>%date{ISO8601} level=[%level] logger=[%logger] thread=[%thread] message=[%class{0}|%M|%line - %message] %replace(exception=[%xException]){'^exception=\[\]$',''}%n</pattern>
         </encoder>
     </appender>
     <root level="OFF">


### PR DESCRIPTION
Making the message field in logs more helpful when scanning. The Class and Method name where the logger originated from will show in the message which will hopefully be helpful!