### PR TITLE
ADR-1460 

### DIFF
--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -29,6 +29,9 @@ class Module extends AbstractModule {
     bind(classOf[DataRequiredAction]).to(classOf[DataRequiredActionImpl]).asEagerSingleton()
 
     // For session based storage instead of cred based, change to SessionIdentifierAction
+    bind(classOf[CheckAffinityGroupIsOrganisationAction])
+      .to(classOf[CheckAffinityGroupIsOrganisationActionImpl])
+      .asEagerSingleton()
     bind(classOf[IdentifyWithEnrolmentAction]).to(classOf[IdentifyWithEnrolmentActionImpl]).asEagerSingleton()
     bind(classOf[IdentifyWithoutEnrolmentAction])
       .to(classOf[IdentifyWithoutEnrolmentActionImpl])

--- a/app/controllers/UnauthorisedController.scala
+++ b/app/controllers/UnauthorisedController.scala
@@ -16,19 +16,23 @@
 
 package controllers
 
-import javax.inject.Inject
+import controllers.actions.CheckAffinityGroupIsOrganisationAction
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.UnauthorisedView
 
+import javax.inject.Inject
+import scala.concurrent.Future
+
 class UnauthorisedController @Inject() (
   val controllerComponents: MessagesControllerComponents,
+  checkAffinityGroupIsOrganisation: CheckAffinityGroupIsOrganisationAction,
   view: UnauthorisedView
 ) extends FrontendBaseController
     with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = Action { implicit request =>
-    Ok(view())
+  def onPageLoad: Action[AnyContent] = checkAffinityGroupIsOrganisation.async { implicit request =>
+    Future.successful(Ok(view(request.isOrganisation)))
   }
 }

--- a/app/controllers/actions/CheckAffinityGroupIsOrganisationAction.scala
+++ b/app/controllers/actions/CheckAffinityGroupIsOrganisationAction.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import com.google.inject.Inject
+import config.FrontendAppConfig
+import controllers.routes
+import models.requests._
+import play.api.Logging
+import play.api.mvc._
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.auth.core._
+import uk.gov.hmrc.auth.core.authorise.Predicate
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.http.HeaderCarrierConverter
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait CheckAffinityGroupIsOrganisationAction
+    extends ActionBuilder[IsOrganisationRequest, AnyContent]
+    with ActionFunction[Request, IsOrganisationRequest]
+
+class CheckAffinityGroupIsOrganisationActionImpl @Inject() (
+  override val authConnector: AuthConnector,
+  val parser: BodyParsers.Default
+)(implicit val executionContext: ExecutionContext)
+    extends CheckAffinityGroupIsOrganisationAction
+    with AuthorisedFunctions
+    with Logging {
+
+  private def predicate: Predicate = Organisation
+  override def invokeBlock[A](
+    request: Request[A],
+    block: IsOrganisationRequest[A] => Future[Result]
+  ): Future[Result] = {
+
+    println("XXXXXXXX")
+
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+
+    authorised(predicate) {
+      block(IsOrganisationRequest(request, isOrganisation = true))
+    } recoverWith { case _ =>
+      block(IsOrganisationRequest(request, isOrganisation = false))
+    }
+  }
+}

--- a/app/controllers/actions/CheckAffinityGroupIsOrganisationAction.scala
+++ b/app/controllers/actions/CheckAffinityGroupIsOrganisationAction.scala
@@ -48,8 +48,6 @@ class CheckAffinityGroupIsOrganisationActionImpl @Inject() (
     block: IsOrganisationRequest[A] => Future[Result]
   ): Future[Result] = {
 
-    println("XXXXXXXX")
-
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequestAndSession(request, request.session)
 
     authorised(predicate) {

--- a/app/models/requests/IsOrganisationRequest.scala
+++ b/app/models/requests/IsOrganisationRequest.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+import play.api.mvc.{Request, WrappedRequest}
+
+case class IsOrganisationRequest[A](request: Request[A], isOrganisation: Boolean) extends WrappedRequest[A](request)

--- a/app/views/UnauthorisedView.scala.html
+++ b/app/views/UnauthorisedView.scala.html
@@ -24,11 +24,12 @@
 
 )
 
-@()(implicit request: Request[_], messages: Messages)
+@(isOrganisation: Boolean)(implicit request: Request[_], messages: Messages)
 
 @layout(
     pageTitle = titleNoForm(messages("unauthorised.title", messages("service.name"))),
-    timeout   = false
+    timeout   = false,
+    isOrganisation = isOrganisation
 ) {
 
 @pageHeading(messages("unauthorised.heading"))

--- a/app/views/templates/Layout.scala.html
+++ b/app/views/templates/Layout.scala.html
@@ -38,7 +38,13 @@
     fullWidthPageLayout: FullWidthMainContent
 )
 
-@(pageTitle: String, showBackLink: Boolean = true, timeout: Boolean = true, showSignOut: Boolean = true, fullWidth: Boolean = false, withPrintCss: Boolean = false)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+@(pageTitle: String, showBackLink: Boolean = true, timeout: Boolean = true, showSignOut: Boolean = true, fullWidth: Boolean = false, withPrintCss: Boolean = false, isOrganisation: Boolean = true)(contentBlock: Html)(implicit request: RequestHeader, messages: Messages)
+
+    @getSignOutUrl(showSignOut: Boolean, isOrganisation: Boolean) = @{
+        if(showSignOut) {
+            Some(controllers.auth.routes.AuthController.signOut(isOrganisation).url)
+        } else None
+    }
 
 @head = {
 
@@ -49,7 +55,7 @@
                 countdown           = Some(appConfig.countdown),
                 keepAliveUrl        = Some(routes.KeepAliveController.keepAlive.url),
                 keepAliveButtonText = Some(messages("timeout.keepAlive")),
-                signOutUrl          = Some(controllers.auth.routes.AuthController.signOut().url),
+                signOutUrl          = Some(controllers.auth.routes.AuthController.signOut(isOrganisation).url),
                 signOutButtonText   = Some(messages("timeout.signOut")),
                 title               = Some(messages("timeout.title")),
                 message             = Some(messages("timeout.message"))
@@ -103,7 +109,7 @@
     headBlock   = Some(head),
     headerBlock = Some(hmrcStandardHeader(
         serviceUrl  = Some(routes.ServiceEntryController.onPageLoad.url),
-        signOutUrl  = if(showSignOut) Some(controllers.auth.routes.AuthController.signOut().url) else None,
+        signOutUrl  = getSignOutUrl(showSignOut, isOrganisation),
         phaseBanner = Some(betaBanner(appConfig.feedbackUrl))
     )),
     beforeContentBlock = Some(beforeContent),

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,7 +12,7 @@ GET         /there-is-a-problem                          controllers.JourneyReco
 
 GET         /return-locked                               controllers.ReturnLockedController.onPageLoad()
 
-GET         /account/sign-out-survey                     controllers.auth.AuthController.signOut()
+GET         /account/sign-out-survey                     controllers.auth.AuthController.signOut(isOrganisation: Boolean)
 GET         /account/signed-out                          controllers.auth.SignedOutController.onPageLoad
 
 GET         /no-access                                   controllers.UnauthorisedController.onPageLoad

--- a/test/controllers/UnauthorisedControllerSpec.scala
+++ b/test/controllers/UnauthorisedControllerSpec.scala
@@ -17,10 +17,26 @@
 package controllers
 
 import base.SpecBase
+import controllers.actions.CheckAffinityGroupIsOrganisationActionImpl
+import models.requests.IsOrganisationRequest
+import play.api.mvc.{Request, Result}
 import play.api.test.Helpers._
 import views.html.UnauthorisedView
 
+import scala.concurrent.Future
+
 class UnauthorisedControllerSpec extends SpecBase {
+
+  val mockCheckAffinityGroupIsOrganisationActionImpl = mock[CheckAffinityGroupIsOrganisationActionImpl]
+
+  def successfulFutureCodeBlock: (Request[_], IsOrganisationRequest[_]) => Future[Result] = (_, _) => {
+    Future.successful(Ok("Test message"))
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockCheckAffinityGroupIsOrganisationActionImpl)
+  }
 
   "Unauthorised Controller" - {
 
@@ -29,6 +45,7 @@ class UnauthorisedControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
+
         val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad.url)
 
         val result = route(application, request).value
@@ -36,7 +53,25 @@ class UnauthorisedControllerSpec extends SpecBase {
         val view = application.injector.instanceOf[UnauthorisedView]
 
         status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, getMessages(application)).toString
+        contentAsString(result) mustEqual view(isOrganisation = true)(request, getMessages(application)).toString
+      }
+    }
+
+    "must return OK and the correct view for a GET when user is not an organisation" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers), isOrganisation = false)
+        .build()
+
+      running(application) {
+
+        val request = FakeRequest(GET, routes.UnauthorisedController.onPageLoad.url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[UnauthorisedView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view(isOrganisation = false)(request, getMessages(application)).toString
       }
     }
   }

--- a/test/controllers/actions/CheckAffinityGroupIsOrganisationActionSpec.scala
+++ b/test/controllers/actions/CheckAffinityGroupIsOrganisationActionSpec.scala
@@ -44,7 +44,6 @@ class CheckAffinityGroupIsOrganisationActionSpec extends SpecBase {
 
   def testCodeBlock(isOrganisationStore: mutable.Map[String, Boolean]): IsOrganisationRequest[_] => Future[Result] = {
     request =>
-
       isOrganisationStore.synchronized {
         isOrganisationStore.put(isOrganisationKey, request.isOrganisation)
       }

--- a/test/controllers/actions/CheckAffinityGroupIsOrganisationActionSpec.scala
+++ b/test/controllers/actions/CheckAffinityGroupIsOrganisationActionSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import models.requests.IsOrganisationRequest
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
+import play.api.http.Status.OK
+import play.api.mvc.{BodyParsers, Result}
+import play.api.test.Helpers.{contentAsString, defaultAwaitTimeout, status}
+import uk.gov.hmrc.auth.core.AffinityGroup.Organisation
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
+
+import scala.concurrent.Future
+
+class CheckAffinityGroupIsOrganisationActionSpec extends SpecBase {
+
+  val defaultBodyParser: BodyParsers.Default = app.injector.instanceOf[BodyParsers.Default]
+  val mockAuthConnector: AuthConnector       = mock[AuthConnector]
+
+  val testContent = "Test result body"
+
+  val newCheckAffinityGroupIsOrganisationAction =
+    new CheckAffinityGroupIsOrganisationActionImpl(mockAuthConnector, defaultBodyParser)
+  def testCodeBlock(isOrganisation: Boolean): IsOrganisationRequest[_] => Future[Result] = { request =>
+    println("Passed in: " + isOrganisation)
+    println("From request: " + request.isOrganisation)
+
+    request.isOrganisation mustBe !isOrganisation
+    Future(Ok(testContent))
+  }
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockAuthConnector)
+  }
+
+  "CheckAffinityGroupIsOrganisationAction .invokeBlock" - {
+    "must execute the block with isOrganisation set to true, when the request is an organisation" in {
+      when(mockAuthConnector.authorise(eqTo(Organisation), eqTo(EmptyRetrieval))(any(), any()))
+        .thenReturn(Future.unit)
+
+      val result: Future[Result] =
+        newCheckAffinityGroupIsOrganisationAction.invokeBlock(FakeRequest(), testCodeBlock(true))
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe testContent
+    }
+    "must execute the block with isOrganisation set to false, when the request is NOT an organisation" in {
+      when(mockAuthConnector.authorise(eqTo(Organisation), eqTo(EmptyRetrieval))(any(), any()))
+        .thenReturn(Future.failed(new Exception("Test Exception")))
+
+      val result: Future[Result] =
+        newCheckAffinityGroupIsOrganisationAction.invokeBlock(FakeRequest(), testCodeBlock(false))
+
+      status(result) mustBe OK
+      contentAsString(result) mustBe testContent
+    }
+  }
+}

--- a/test/controllers/actions/FakeCheckAffinityGroupAction.scala
+++ b/test/controllers/actions/FakeCheckAffinityGroupAction.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import models.requests.IsOrganisationRequest
+import play.api.mvc._
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+case class FakeIsOrganisation(isOrganisation: Boolean)
+
+class FakeCheckAffinityGroupAction @Inject() (bodyParsers: PlayBodyParsers, fakeIsOrganisation: FakeIsOrganisation)
+    extends CheckAffinityGroupIsOrganisationAction {
+
+  def invokeBlock[A](
+    request: Request[A],
+    block: IsOrganisationRequest[A] => Future[Result]
+  ): Future[Result] =
+    block(IsOrganisationRequest(request, fakeIsOrganisation.isOrganisation))
+
+  override def parser: BodyParser[AnyContent] =
+    bodyParsers.default
+
+  override protected def executionContext: ExecutionContext =
+    scala.concurrent.ExecutionContext.Implicits.global
+}

--- a/test/controllers/auth/AuthControllerSpec.scala
+++ b/test/controllers/auth/AuthControllerSpec.scala
@@ -45,7 +45,7 @@ class AuthControllerSpec extends SpecBase {
       running(application) {
 
         val appConfig = application.injector.instanceOf[FrontendAppConfig]
-        val request   = FakeRequestWithoutSession(GET, routes.AuthController.signOut().url)
+        val request   = FakeRequestWithoutSession(GET, routes.AuthController.signOut(true).url)
 
         val result = route(application, request).value
 
@@ -71,7 +71,7 @@ class AuthControllerSpec extends SpecBase {
       running(application) {
 
         val appConfig = application.injector.instanceOf[FrontendAppConfig]
-        val request   = FakeRequest(GET, routes.AuthController.signOut().url)
+        val request   = FakeRequest(GET, routes.AuthController.signOut(true).url)
 
         val result = route(application, request).value
 


### PR DESCRIPTION
Ticket [ADR-1460](https://jira.tools.tax.service.gov.uk/browse/ADR-1460). What I did is create a new action that checks if the user is registered as an organisation. If this is the case then when clicking the sign out button, everything works the same as it currently is. If the user is NOT an organisation, then we will not try and identify them, and just redirect them to the sign out url without trying to remove the lock on their account (because in this case they would not have the lock, because they are not signed in and do not have associated AppaIds). Apart from this, the functionality is the same.