### PR TITLE
ADR-1445 found places where minus signs were spilling onto other lines and eliminated them

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -23,3 +23,7 @@
 .govuk-grid-column-full {
   overflow: auto;
 }
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -67,6 +67,7 @@ object Constants {
   val visuallyHiddenCssClass     = "govuk-visually-hidden"
   val textAlignRightWrapCssClass = "text-align-right-wrap"
   val numericCellClass           = "govuk-table__cell--numeric"
+  val noWrap                     = "no-wrap"
 
   val blueTagCssClass  = "govuk-tag--blue"
   val greenTagCssClass = "govuk-tag--green"

--- a/app/config/Constants.scala
+++ b/app/config/Constants.scala
@@ -58,16 +58,14 @@ object Constants {
 
   val rowsPerPage = 15
 
-  val bodyCssClass               = "govuk-body"
-  val oneQuarterCssClass         = "govuk-!-width-one-quarter"
-  val oneHalfCssClass            = "govuk-!-width-one-half"
-  val threeQuartersCssClass      = "govuk-!-width-three-quarters"
-  val textAlignRightCssClass     = "text-align-right"
-  val boldFontCssClass           = "govuk-!-font-weight-bold"
-  val visuallyHiddenCssClass     = "govuk-visually-hidden"
-  val textAlignRightWrapCssClass = "text-align-right-wrap"
-  val numericCellClass           = "govuk-table__cell--numeric"
-  val noWrap                     = "no-wrap"
+  val bodyCssClass           = "govuk-body"
+  val oneQuarterCssClass     = "govuk-!-width-one-quarter"
+  val oneHalfCssClass        = "govuk-!-width-one-half"
+  val threeQuartersCssClass  = "govuk-!-width-three-quarters"
+  val textAlignRightCssClass = "text-align-right"
+  val boldFontCssClass       = "govuk-!-font-weight-bold"
+  val visuallyHiddenCssClass = "govuk-visually-hidden"
+  val numericCellClass       = "govuk-table__cell--numeric"
 
   val blueTagCssClass  = "govuk-tag--blue"
   val greenTagCssClass = "govuk-tag--green"
@@ -112,6 +110,7 @@ object Constants {
 
     val textAlignRightCssClass     = "text-align-right"
     val textAlignRightWrapCssClass = "text-align-right-wrap"
+    val noWrap                     = "no-wrap"
 
     val boldFontCssClass = "govuk-!-font-weight-bold"
 

--- a/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
+++ b/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
@@ -17,7 +17,6 @@
 package viewmodels.checkAnswers.checkAndSubmit
 
 import cats.data.EitherT
-import config.Constants
 import config.Constants.Css
 import connectors.AlcoholDutyCalculatorConnector
 import models.AlcoholRegime.{Beer, Cider, OtherFermentedProduct, Spirits, Wine}
@@ -296,7 +295,7 @@ class DutyDueForThisReturnHelper @Inject() (
           ),
           TableRow(
             Text(Money.format(totalAdjustment)),
-            classes = s"${Css.summaryListValueCssClass} ${Constants.noWrap}"
+            classes = s"${Css.summaryListValueCssClass} ${Css.noWrap}"
           )
         ),
         actions = Seq(

--- a/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
+++ b/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
@@ -17,6 +17,7 @@
 package viewmodels.checkAnswers.checkAndSubmit
 
 import cats.data.EitherT
+import config.Constants
 import config.Constants.Css
 import connectors.AlcoholDutyCalculatorConnector
 import models.AlcoholRegime.{Beer, Cider, OtherFermentedProduct, Spirits, Wine}
@@ -295,7 +296,7 @@ class DutyDueForThisReturnHelper @Inject() (
           ),
           TableRow(
             Text(Money.format(totalAdjustment)),
-            classes = Css.summaryListValueCssClass
+            classes = s"${Css.summaryListValueCssClass} ${Constants.noWrap}"
           )
         ),
         actions = Seq(

--- a/app/views/adjustment/AdjustmentDutyDueView.scala.html
+++ b/app/views/adjustment/AdjustmentDutyDueView.scala.html
@@ -29,13 +29,14 @@
         bulletList: BulletList
 )
 
-@(adjustmentType: AdjustmentType, volume:BigDecimal, duty:BigDecimal, pureAlcoholVolume:BigDecimal, taxCode:String, rate:BigDecimal, repackagedRate:BigDecimal, repackagedDuty:BigDecimal, newDuty:BigDecimal)(implicit request: Request[_], messages: Messages)
+@(adjustmentType: AdjustmentType, volume: BigDecimal, duty: BigDecimal, pureAlcoholVolume: BigDecimal, taxCode: String, rate: BigDecimal, repackagedRate: BigDecimal, repackagedDuty: BigDecimal, newDuty: BigDecimal)(implicit request: Request[_], messages: Messages)
 
 @heading = @{
-    adjustmentType match {
-        case AdjustmentType.RepackagedDraughtProducts => pageHeadingWithMonetaryValue(messages("adjustmentDutyDue.heading"), Money.format(newDuty))
-        case _ => pageHeadingWithMonetaryValue(messages("adjustmentDutyDue.heading"), Money.format(duty))
+    val dutyToShow: BigDecimal = adjustmentType match {
+        case AdjustmentType.RepackagedDraughtProducts => newDuty
+        case _ => duty
     }
+    pageHeadingWithMonetaryValue(messages("adjustmentDutyDue.heading"), dutyToShow)
 }
 
 @layout(pageTitle = titleNoForm(messages("adjustmentDutyDue.title", Money.format(duty)))) {

--- a/app/views/adjustment/AdjustmentDutyDueView.scala.html
+++ b/app/views/adjustment/AdjustmentDutyDueView.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import components.{SectionHeading, PageHeading, Paragraph, BulletList}
+@import components.{SectionHeading, PageHeading, PageHeadingWithMonetaryValue, Paragraph, BulletList}
 @import models.adjustment.AdjustmentType
 @import models.adjustment.AdjustmentType.RepackagedDraughtProducts
 @import viewmodels.Money
@@ -23,12 +23,20 @@
         layout: templates.Layout,
         govukButton: GovukButton,
         sectionHeading: SectionHeading,
+        pageHeadingWithMonetaryValue: PageHeadingWithMonetaryValue,
         pageHeading: PageHeading,
         paragraph: Paragraph,
         bulletList: BulletList
 )
 
 @(adjustmentType: AdjustmentType, volume:BigDecimal, duty:BigDecimal, pureAlcoholVolume:BigDecimal, taxCode:String, rate:BigDecimal, repackagedRate:BigDecimal, repackagedDuty:BigDecimal, newDuty:BigDecimal)(implicit request: Request[_], messages: Messages)
+
+@heading = @{
+    adjustmentType match {
+        case AdjustmentType.RepackagedDraughtProducts => pageHeadingWithMonetaryValue(messages("adjustmentDutyDue.heading"), Money.format(newDuty))
+        case _ => pageHeadingWithMonetaryValue(messages("adjustmentDutyDue.heading"), Money.format(duty))
+    }
+}
 
 @layout(pageTitle = titleNoForm(messages("adjustmentDutyDue.title", Money.format(duty)))) {
 
@@ -37,13 +45,8 @@
         text = messages(s"section.adjustment.$adjustmentType"),
     )
 
-    @if(adjustmentType != RepackagedDraughtProducts) {
-        @pageHeading(messages("adjustmentDutyDue.heading", Money.format(duty)))
-    }
+    @heading
 
-    @if(adjustmentType == RepackagedDraughtProducts) {
-        @pageHeading(messages("adjustmentDutyDue.heading", Money.format(newDuty)))
-    }
     @paragraph(messages("adjustmentDutyDue.paragraph1"))
 
     @if(adjustmentType != RepackagedDraughtProducts) {
@@ -71,4 +74,4 @@
         .asLink(controllers.adjustment.routes.CheckYourAnswersController.onPageLoad().url)
     )
 
-}
+}@import views.html.components.PageHeadingWithMonetaryValue

--- a/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
+++ b/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import components.{SectionHeading, PageHeading, Paragraph, BulletList, SubHeading}
+@import components.{SectionHeading, PageHeading, PageHeadingWithMonetaryValue, Paragraph, BulletList, SubHeading}
 @import config.Constants.Css
 @import viewmodels.checkAnswers.checkAndSubmit.DutyDueForThisReturnViewModel
 @import viewmodels.Money
@@ -25,6 +25,7 @@
         govukButton: GovukButton,
         sectionHeading: SectionHeading,
         pageHeading: PageHeading,
+        pageHeadingWithMonetaryValue: PageHeadingWithMonetaryValue,
         paragraph: Paragraph,
         subHeading: SubHeading,
         bulletList: BulletList,
@@ -43,16 +44,24 @@
   }
 }
 
+@heading = @{
+    if (dutyDueViewModel.totalDue == 0) {
+        pageHeading(messages("dutyDueForThisReturn.nil.heading"))
+    } else {
+        pageHeadingWithMonetaryValue(messages("dutyDueForThisReturn.heading"), Money.format(dutyDueViewModel.totalDue))
+    }
+}
+
 @layout(pageTitle = titleNoForm(titleMessage)) {
   @formHelper(action = controllers.checkAndSubmit.routes.DutyDueForThisReturnController.onSubmit(), Symbol("autoComplete") -> "off") {
-    @sectionHeading(
+      @sectionHeading(
       id = "dutyDueForThisReturn-section",
       text = messages("section.checkAndSubmit"),
     )
 
-    @if(dutyDueViewModel.totalDue == 0) {
-      @pageHeading(messages("dutyDueForThisReturn.nil.heading"))
+      @heading
 
+    @if(dutyDueViewModel.totalDue == 0) {
       @paragraph(messages("dutyDueForThisReturn.nil.p1"))
 
       @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
@@ -61,8 +70,6 @@
     }
 
     @if(dutyDueViewModel.totalDue > 0) {
-      @pageHeading(messages("dutyDueForThisReturn.heading", Money.format(dutyDueViewModel.totalDue)))
-
       @paragraph(messages("dutyDueForThisReturn.positive.p1"))
 
       @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
@@ -73,8 +80,6 @@
     }
 
     @if(dutyDueViewModel.totalDue < 0) {
-      @pageHeading(messages("dutyDueForThisReturn.heading", Money.format(dutyDueViewModel.totalDue)))
-
       @paragraph(messages("dutyDueForThisReturn.negative.p1"))
 
       @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)

--- a/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
+++ b/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
@@ -48,7 +48,7 @@
     if (dutyDueViewModel.totalDue == 0) {
         pageHeading(messages("dutyDueForThisReturn.nil.heading"))
     } else {
-        pageHeadingWithMonetaryValue(messages("dutyDueForThisReturn.heading"), Money.format(dutyDueViewModel.totalDue))
+        pageHeadingWithMonetaryValue(messages("dutyDueForThisReturn.heading"), dutyDueViewModel.totalDue)
     }
 }
 

--- a/app/views/checkAndSubmit/ReturnSubmittedView.scala.html
+++ b/app/views/checkAndSubmit/ReturnSubmittedView.scala.html
@@ -44,7 +44,7 @@
 
 @negPanelContent = {
     @paragraph(messages("returnSubmitted.panel.body.reference", viewModel.returnDetails.chargeReference.get.value), classes = "")
-    @paragraphWithMonetaryValue(s"${messages("returnSubmitted.panel.body.dutyOwed")}", Money.format(viewModel.returnDetails.amount), classes = "")
+    @paragraphWithMonetaryValue(s"${messages("returnSubmitted.panel.body.dutyOwed")}", viewModel.returnDetails.amount, classes = "")
     @paragraph(messages("returnSubmitted.panel.body.nil"), classes = "")
 }
 

--- a/app/views/checkAndSubmit/ReturnSubmittedView.scala.html
+++ b/app/views/checkAndSubmit/ReturnSubmittedView.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import components.{Link, PageHeading, Paragraph, SectionHeading, SubHeading}
+@import components.{Link, PageHeading, Paragraph, ParagraphWithMonetaryValue, SectionHeading, SubHeading}
 @import viewmodels.Money
 @import viewmodels.returns.ReturnSubmittedViewModel
 
@@ -26,6 +26,7 @@
         pageHeading: PageHeading,
         govukPanel : GovukPanel,
         paragraph: Paragraph,
+        paragraphWithMonetaryValue: ParagraphWithMonetaryValue,
         link: Link,
         govukWarningText : GovukWarningText
 )
@@ -34,7 +35,7 @@
 
 @posPanelContent = {
     @paragraph(messages("returnSubmitted.panel.body.reference", viewModel.returnDetails.chargeReference.get.value), classes = "")
-    @paragraph(s"${messages("returnSubmitted.panel.body.balanceDue")} ${messages(Money.format(viewModel.returnDetails.amount))}", classes = "")
+    @paragraph(s"${messages("returnSubmitted.panel.body.balanceDue")} ${Money.format(viewModel.returnDetails.amount)}", classes = "")
 }
 
 @nilPanelContent = {
@@ -43,7 +44,7 @@
 
 @negPanelContent = {
     @paragraph(messages("returnSubmitted.panel.body.reference", viewModel.returnDetails.chargeReference.get.value), classes = "")
-    @paragraph(s"${messages("returnSubmitted.panel.body.dutyOwed")} ${messages(Money.format(viewModel.returnDetails.amount))}", classes = "")
+    @paragraphWithMonetaryValue(s"${messages("returnSubmitted.panel.body.dutyOwed")}", Money.format(viewModel.returnDetails.amount), classes = "")
     @paragraph(messages("returnSubmitted.panel.body.nil"), classes = "")
 }
 

--- a/app/views/components/PageHeadingWithMonetaryValue.scala.html
+++ b/app/views/components/PageHeadingWithMonetaryValue.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.Constants.Css
+@import config.Constants
+
+@this()
+
+@(text: String, amount: String)
+
+<h1 class="@Css.headingXLCssClass">@text <span class="@Constants.noWrap">@amount</span></h1>

--- a/app/views/components/PageHeadingWithMonetaryValue.scala.html
+++ b/app/views/components/PageHeadingWithMonetaryValue.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import config.Constants.Css
-@import config.Constants
+@import viewmodels.Money
 
 @this()
 
-@(text: String, amount: String)
+@(text: String, amount: BigDecimal)(implicit messages: Messages)
 
-<h1 class="@Css.headingXLCssClass">@text <span class="@Constants.noWrap">@amount</span></h1>
+<h1 class="@Css.headingXLCssClass">@text <span class="@Css.noWrap">@Money.format(amount)</span></h1>

--- a/app/views/components/ParagraphWithMonetaryValue.scala.html
+++ b/app/views/components/ParagraphWithMonetaryValue.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import config.Constants.Css
-@import config.Constants
+@import viewmodels.Money
 
 @this()
 
-@(content: Content, amount: String, classes: String = Css.bodyCssClass, id: Option[String] = None)
+@(content: Content, amount: BigDecimal, classes: String = Css.bodyCssClass, id: Option[String] = None)(implicit messages: Messages)
 
-<p class="@classes" @id.map{id => id="@id"}>@content.asHtml <span class=@Constants.noWrap>@amount</span></p>
+<p class="@classes" @id.map{id => id="@id"}>@content.asHtml <span class=@Css.noWrap>@Money.format(amount)</span></p>

--- a/app/views/components/ParagraphWithMonetaryValue.scala.html
+++ b/app/views/components/ParagraphWithMonetaryValue.scala.html
@@ -1,0 +1,24 @@
+@*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.Constants.Css
+@import config.Constants
+
+@this()
+
+@(content: Content, amount: String, classes: String = Css.bodyCssClass, id: Option[String] = None)
+
+<p class="@classes" @id.map{id => id="@id"}>@content.asHtml <span class=@Constants.noWrap>@amount</span></p>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -835,7 +835,7 @@ adjustmentSmallProducerReliefDutyRate.error.decimalPlaces = Your Small Producer 
 adjustmentSmallProducerReliefDutyRate.change.hidden = SPR duty rate
 
 adjustmentDutyDue.title = The duty value for this adjustment is {0}
-adjustmentDutyDue.heading = The duty value for this adjustment is {0}
+adjustmentDutyDue.heading = The duty value for this adjustment is
 adjustmentDutyDue.paragraph1 = This is because:
 adjustmentDutyDue.bulletList.1 = you declared {0} litres of pure alcohol (LPA)
 adjustmentDutyDue.bulletList.2 = the duty rate is {0} per litre of pure alcohol
@@ -883,7 +883,7 @@ overDeclarationReason.error.length = The reason must be {0} characters or less
 
 dutyDueForThisReturn.title = The duty due for this return is {0}
 dutyDueForThisReturn.nil.title = No duty due
-dutyDueForThisReturn.heading = The duty due for this return is {0}
+dutyDueForThisReturn.heading = The duty due for this return is
 dutyDueForThisReturn.nil.heading = No duty due
 dutyDueForThisReturn.positive.p1 = You will be liable for this amount once you send your return.
 dutyDueForThisReturn.negative.p1 = Your return has a negative duty value. You will be able to claim this back after sending your return. If you do not claim it back we will automatically deduct it from your next return.


### PR DESCRIPTION
The ticket is https://jira.tools.tax.service.gov.uk/browse/ADR-1445. I used the nowrap css field to ensure that the minus sign and number were seen as one entity to stop the minus from going onto new lines. I created some new scala.html templates to help with this in order to avoid having to use raw html in views which i think is generally avoided on this team/on platform/scaffold in general