### PR TITLE
ADR-1557 Add regression unit tests for data removal + clear correct fields in adjustments

### DIFF
--- a/app/controllers/adjustment/DeclareAdjustmentQuestionController.scala
+++ b/app/controllers/adjustment/DeclareAdjustmentQuestionController.scala
@@ -22,7 +22,7 @@ import forms.adjustment.DeclareAdjustmentQuestionFormProvider
 import javax.inject.Inject
 import models.{Mode, UserAnswers}
 import navigation.AdjustmentNavigator
-import pages.adjustment.{AdjustmentEntryListPage, AdjustmentListPage, AdjustmentTotalPage, CurrentAdjustmentEntryPage, DeclareAdjustmentQuestionPage}
+import pages.adjustment.{AdjustmentEntryListPage, AdjustmentListPage, AdjustmentTotalPage, CurrentAdjustmentEntryPage, DeclareAdjustmentQuestionPage, OverDeclarationTotalPage, UnderDeclarationTotalPage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import connectors.UserAnswersConnector
@@ -77,7 +77,14 @@ class DeclareAdjustmentQuestionController @Inject() (
       Try(userAnswer)
     } else {
       userAnswer.remove(
-        List(AdjustmentEntryListPage, AdjustmentListPage, CurrentAdjustmentEntryPage, AdjustmentTotalPage)
+        List(
+          AdjustmentEntryListPage,
+          AdjustmentListPage,
+          CurrentAdjustmentEntryPage,
+          AdjustmentTotalPage,
+          UnderDeclarationTotalPage,
+          OverDeclarationTotalPage
+        )
       )
     }
 }

--- a/app/controllers/declareDuty/DeclareAlcoholDutyQuestionController.scala
+++ b/app/controllers/declareDuty/DeclareAlcoholDutyQuestionController.scala
@@ -77,12 +77,16 @@ class DeclareAlcoholDutyQuestionController @Inject() (
         )
   }
 
-  private def checkIfOneRegimeAndUpdateUserAnswer(userAnswer: UserAnswers): Try[UserAnswers] =
-    if (userAnswer.regimes.regimes.size == 1) {
+  private def checkIfOneRegimeAndUpdateUserAnswer(userAnswer: UserAnswers): Try[UserAnswers] = {
+    val a = userAnswer.regimes
+    val b = a.regimes
+    val c = b.size
+    if (c == 1) {
       userAnswer.set(AlcoholTypePage, userAnswer.regimes.regimes)
     } else {
       Try(userAnswer)
     }
+  }
 
   private def filterAlcoholDutyQuestionAnswer(userAnswer: UserAnswers, value: Boolean): Try[UserAnswers] =
     if (value) {

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -25,7 +25,7 @@ import org.mockito.MockitoSugar
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.{OptionValues, TryValues}
+import org.scalatest.{BeforeAndAfterEach, OptionValues, TryValues}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}
@@ -50,7 +50,8 @@ trait SpecBase
     with IntegrationPatience
     with ModelGenerators
     with TestData
-    with TestPages {
+    with TestPages
+    with BeforeAndAfterEach {
   def getMessages(app: Application): Messages = app.injector.instanceOf[MessagesApi].preferred(FakeRequest())
 
   val fakeIdentifierUserDetails = FakeIdentifierUserDetails(appaId, groupId, internalId)

--- a/test/controllers/adjustment/DeclareAdjustmentQuestionControllerSpec.scala
+++ b/test/controllers/adjustment/DeclareAdjustmentQuestionControllerSpec.scala
@@ -18,25 +18,35 @@ package controllers.adjustment
 
 import base.SpecBase
 import forms.adjustment.DeclareAdjustmentQuestionFormProvider
-import models.NormalMode
+import models.{NormalMode, UserAnswers}
 import navigation.{AdjustmentNavigator, FakeAdjustmentNavigator}
 import org.mockito.ArgumentMatchers.any
-import pages.adjustment.DeclareAdjustmentQuestionPage
+import pages.adjustment.{AdjustmentEntryListPage, AdjustmentListPage, AdjustmentTotalPage, CurrentAdjustmentEntryPage, DeclareAdjustmentQuestionPage, OverDeclarationTotalPage, UnderDeclarationTotalPage}
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.Helpers._
 import connectors.UserAnswersConnector
+import org.mockito.ArgumentMatchersSugar.eqTo
 import uk.gov.hmrc.http.HttpResponse
 import views.html.adjustment.DeclareAdjustmentQuestionView
 
+import scala.util.Success
 import scala.concurrent.Future
 
 class DeclareAdjustmentQuestionControllerSpec extends SpecBase {
 
   def onwardRoute = Call("GET", "/foo")
 
-  val formProvider = new DeclareAdjustmentQuestionFormProvider()
-  val form         = formProvider()
+  val formProvider  = new DeclareAdjustmentQuestionFormProvider()
+  val form          = formProvider()
+  val pagesToDelete = List(
+    AdjustmentEntryListPage,
+    AdjustmentListPage,
+    CurrentAdjustmentEntryPage,
+    AdjustmentTotalPage,
+    UnderDeclarationTotalPage,
+    OverDeclarationTotalPage
+  )
 
   lazy val declareAdjustmentQuestionRoute = routes.DeclareAdjustmentQuestionController.onPageLoad(NormalMode).url
 
@@ -102,14 +112,23 @@ class DeclareAdjustmentQuestionControllerSpec extends SpecBase {
       }
     }
 
-    "must redirect to the Task list  when valid question is answered as No" in {
-
-      val mockUserAnswersConnector = mock[UserAnswersConnector]
+    "must redirect to the Task list and clear user answers when valid question is answered as No" in {
+      val mockUserAnswersConnector     = mock[UserAnswersConnector]
+      val mockUserAnswers: UserAnswers = mock[UserAnswers]
 
       when(mockUserAnswersConnector.set(any())(any())) thenReturn Future.successful(mock[HttpResponse])
+      when(
+        mockUserAnswers.set(eqTo(DeclareAdjustmentQuestionPage), eqTo(false))(any())
+      ) thenReturn Success(
+        mockUserAnswers
+      )
+      when(mockUserAnswers.remove(eqTo(pagesToDelete))) thenReturn emptyUserAnswers.set(
+        DeclareAdjustmentQuestionPage,
+        false
+      )
 
       val application =
-        applicationBuilder(userAnswers = Some(emptyUserAnswers))
+        applicationBuilder(userAnswers = Some(mockUserAnswers))
           .overrides(
             bind[AdjustmentNavigator].toInstance(new FakeAdjustmentNavigator(onwardRoute, true)),
             bind[UserAnswersConnector].toInstance(mockUserAnswersConnector)
@@ -125,6 +144,10 @@ class DeclareAdjustmentQuestionControllerSpec extends SpecBase {
 
         status(result) mustEqual SEE_OTHER
         redirectLocation(result).value mustEqual onwardRoute.url
+
+        verify(mockUserAnswersConnector, times(1)).set(any())(any())
+        verify(mockUserAnswers, times(1)).set(eqTo(DeclareAdjustmentQuestionPage), eqTo(false))(any())
+        verify(mockUserAnswers, times(1)).remove(eqTo(pagesToDelete))
       }
     }
 

--- a/test/controllers/spiritsQuestions/DeclareQuarterlySpiritsControllerSpec.scala
+++ b/test/controllers/spiritsQuestions/DeclareQuarterlySpiritsControllerSpec.scala
@@ -37,6 +37,12 @@ import scala.util.Success
 class DeclareQuarterlySpiritsControllerSpec extends SpecBase {
   val userAnswersPreviouslyAnswered = emptyUserAnswers.set(DeclareQuarterlySpiritsPage, true).success.value
   val mockUserAnswers: UserAnswers  = mock[UserAnswers]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockUserAnswers)
+  }
+
   "DeclareQuarterlySpirits Controller" - {
     "must return OK and the correct view for a GET" in new SetUp(Some(emptyUserAnswers), true) {
       running(application) {


### PR DESCRIPTION
Greetings reader. This Pull Request is for the ticket: https://jira.tools.tax.service.gov.uk/browse/ADR-1557. I added some regression tests to make sure that the data teardown for when a user clicks No to any of the initial questions in journeys is working correctly as there have been some bugs in this and it was mostly unautomatedtested. One of these aforementioned bugs meant that some fields were not being torndown when they should have been. I added these to the list that should be deleted and made sure it was in the test!