### PR TITLE
ADR-1380 Submission duty summary shown in entered order, not view order

### DIFF
--- a/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
+++ b/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
@@ -80,7 +80,8 @@ class DutyDueForThisReturnHelper @Inject() (
   ): EitherT[Future, String, Seq[Tuple2[AlcoholRegime, AlcoholDuty]]] =
     (userAnswers.get(DeclareAlcoholDutyQuestionPage), userAnswers.get(AlcoholDutyPage)) match {
       case (Some(false), _)                  => EitherT.rightT(Seq.empty)
-      case (Some(true), Some(alcoholDuties)) => EitherT.rightT(alcoholDuties.toSeq.sortBy(dutyDueOrder.indexOf(_)))
+      case (Some(true), Some(alcoholDuties)) =>
+        EitherT.rightT(alcoholDuties.toSeq.sortBy { case (regime, _) => dutyDueOrder.indexOf(regime) })
       case (_, _)                            => EitherT.leftT("Unable to get duties due when calculating duty due")
     }
 


### PR DESCRIPTION
[ADR-1380](https://jira.tools.tax.service.gov.uk/browse/ADR-1380) ticket was to fix the order that duty is shown on the duty due for this return page. @Bradleigh-L and I implemented this with TDD, first writing a failing test for checking the order of the items shown on this table, then implementing the suggested fix from the ticket.