### PR TITLE
ADR-1726 | Move how much you need to declare inputs into fieldsets to give context to error messages in relation to abv range

### DIFF
--- a/app/views/declareDuty/HowMuchDoYouNeedToDeclareView.scala.html
+++ b/app/views/declareDuty/HowMuchDoYouNeedToDeclareView.scala.html
@@ -113,43 +113,50 @@ govukFieldset : GovukFieldset
         @if(howMuchDoYouNeedToDeclareHelper.draught.nonEmpty) {
           @subHeading(messages("howMuchDoYouNeedToDeclare.draught.heading", messages(s"return.regime.$regime")), classes = Css.headingMCssClass)
           @for((quantityViewModel, index) <- howMuchDoYouNeedToDeclareHelper.draught.zipWithIndex) {
-            @subHeading(quantityViewModel.category, classes = Css.headingSCssClass)
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
-                key = "totalLitres",
-                label = LabelViewModel(messages("return.journey.totalLitres", messages(s"return.regime.$regime"))),
-                errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_totalLitres"),
-                value = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}].totalLitres").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.hint")))
-            )
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
-                key = "pureAlcohol",
-                label = LabelViewModel(messages("return.journey.pureAlcohol")),
-                errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_pureAlcohol"),
-                value = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}].pureAlcohol").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.pureAlcohol.hint")))
-            )
-
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
-                key = "taxType",
-                label = LabelViewModel(Text("")),
-                errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_taxType"),
-                value = Some(quantityViewModel.id)
-              ).hidden
-            )
+            @govukFieldset(Fieldset(
+                legend = Some(Legend(
+                content = Text(quantityViewModel.category),
+                classes = "govuk-fieldset__legend--s",
+                isPageHeading = false
+              )),
+              html = HtmlFormat.fill(List(
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
+                    key = "totalLitres",
+                    label = LabelViewModel(messages("return.journey.totalLitres", messages(s"return.regime.$regime"))),
+                    errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_totalLitres"),
+                    value = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}].totalLitres").value
+                  )
+                  .asNumeric()
+                  .withWidth(Fixed10)
+                  .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                  .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.hint")))
+                ),
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
+                    key = "pureAlcohol",
+                    label = LabelViewModel(messages("return.journey.pureAlcohol")),
+                    errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_pureAlcohol"),
+                    value = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}].pureAlcohol").value
+                  )
+                  .asNumeric()
+                  .withWidth(Fixed10)
+                  .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                  .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.pureAlcohol.hint")))
+                ),
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[${index + howMuchDoYouNeedToDeclareHelper.core.size}]"),
+                    key = "taxType",
+                    label = LabelViewModel(Text("")),
+                    errorMessageField = form(s"volumes_${index + howMuchDoYouNeedToDeclareHelper.core.size}_taxType"),
+                    value = Some(quantityViewModel.id)
+                  ).hidden
+                )
+              ))
+            ))
           }
         }
 

--- a/app/views/declareDuty/HowMuchDoYouNeedToDeclareView.scala.html
+++ b/app/views/declareDuty/HowMuchDoYouNeedToDeclareView.scala.html
@@ -30,7 +30,8 @@
     subHeading: SubHeading,
     pageHeading: PageHeading,
     paragraph: Paragraph,
-    govukWarningText: GovukWarningText
+    govukWarningText: GovukWarningText,
+govukFieldset : GovukFieldset
 )
 
 @(form: Form[_], regime: AlcoholRegime, howMuchDoYouNeedToDeclareHelper: CategoriesByRateTypeViewModel, mode: Mode)(implicit request: Request[_], messages: Messages)
@@ -62,43 +63,50 @@
         @if(howMuchDoYouNeedToDeclareHelper.core.nonEmpty) {
           @subHeading(messages("howMuchDoYouNeedToDeclare.core.heading", messages(s"return.regime.$regime")), classes = Css.headingMCssClass)
           @for((quantityViewModel, index) <- howMuchDoYouNeedToDeclareHelper.core.zipWithIndex) {
-            @subHeading(quantityViewModel.category, classes = Css.headingSCssClass)
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[$index]"),
-                key = "totalLitres",
-                label = LabelViewModel(messages("return.journey.totalLitres", messages(s"return.regime.$regime"))),
-                errorMessageField = form(s"volumes_${index}_totalLitres"),
-                value = form(s"volumes[$index].totalLitres").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.hint")))
-            )
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[$index]"),
-                key = "pureAlcohol",
-                label = LabelViewModel(messages("return.journey.pureAlcohol")),
-                errorMessageField = form(s"volumes_${index}_pureAlcohol"),
-                value = form(s"volumes[$index].pureAlcohol").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.pureAlcohol.hint")))
-            )
-
-            @govukInput(
-              InputViewModel(
-                field = form(s"volumes[$index]"),
-                key = "taxType",
-                label = LabelViewModel(Text("")),
-                errorMessageField = form(s"volumes_${index}_taxType"),
-                value = Some(quantityViewModel.id)
-              ).hidden
-            )
+            @govukFieldset(Fieldset(
+                legend = Some(Legend(
+                content = Text(quantityViewModel.category),
+                classes = "govuk-fieldset__legend--s",
+                isPageHeading = false
+              )),
+              html = HtmlFormat.fill(List(
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[$index]"),
+                    key = "totalLitres",
+                    label = LabelViewModel(messages("return.journey.totalLitres", messages(s"return.regime.$regime"))),
+                    errorMessageField = form(s"volumes_${index}_totalLitres"),
+                    value = form(s"volumes[$index].totalLitres").value
+                  )
+                  .asNumeric()
+                  .withWidth(Fixed10)
+                  .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                  .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.hint")))
+                ),
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[$index]"),
+                    key = "pureAlcohol",
+                    label = LabelViewModel(messages("return.journey.pureAlcohol")),
+                    errorMessageField = form(s"volumes_${index}_pureAlcohol"),
+                    value = form(s"volumes[$index].pureAlcohol").value
+                  )
+                  .asNumeric()
+                  .withWidth(Fixed10)
+                  .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                  .withHint(Hint(content = messages("howMuchDoYouNeedToDeclare.pureAlcohol.hint")))
+                ),
+                govukInput(
+                  InputViewModel(
+                    field = form(s"volumes[$index]"),
+                    key = "taxType",
+                    label = LabelViewModel(Text("")),
+                    errorMessageField = form(s"volumes_${index}_taxType"),
+                    value = Some(quantityViewModel.id)
+                  ).hidden
+                )
+              ))
+           ))
           }
         }
 


### PR DESCRIPTION
This PR makes use of https://design-system.service.gov.uk/components/fieldset/ to refactor the code to add context to the input fields and errors for specific ABV range sections of the page. 

If @james-delaney-designer  is happy that this will be OK for accessibility then we can create a ticket from the spike here and roll this out across the service? 

https://jira.tools.tax.service.gov.uk/browse/ADR-1726

<img width="1506" alt="Screenshot 2025-01-23 at 13 54 21" src="https://github.com/user-attachments/assets/d251853c-d6cf-4fdb-a8e3-ec1b2c6a2603" />

