### PR TITLE
ADR-1899 Fix order of alcohol regimes in View return duty suspended table

### DIFF
--- a/app/viewmodels/returns/ViewReturnViewModel.scala
+++ b/app/viewmodels/returns/ViewReturnViewModel.scala
@@ -302,14 +302,14 @@ class ViewReturnViewModel @Inject() (appConfig: FrontendAppConfig) {
         netDutySuspension.totalLtsPureAlcoholCider
       ),
       netDutySuspensionCell(
-        AlcoholRegime.Spirits.regimeMessageKey,
-        netDutySuspension.totalLtsSpirit,
-        netDutySuspension.totalLtsPureAlcoholSpirit
-      ),
-      netDutySuspensionCell(
         AlcoholRegime.Wine.regimeMessageKey,
         netDutySuspension.totalLtsWine,
         netDutySuspension.totalLtsPureAlcoholWine
+      ),
+      netDutySuspensionCell(
+        AlcoholRegime.Spirits.regimeMessageKey,
+        netDutySuspension.totalLtsSpirit,
+        netDutySuspension.totalLtsPureAlcoholSpirit
       ),
       netDutySuspensionCell(
         AlcoholRegime.OtherFermentedProduct.regimeMessageKey,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -2,13 +2,13 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVersion = "9.9.0"
-  private val hmrcMongoVersion = "2.5.0"
+  private val bootstrapVersion = "9.11.0"
+  private val hmrcMongoVersion = "2.6.0"
   val mockitoScalaVersion = "1.17.37"
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"     % "11.11.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"     % "11.12.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30"  % "3.2.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"     % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"             % hmrcMongoVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ resolvers += "Typesafe Releases" at "https://repo.typesafe.com/typesafe/releases
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.24.0" exclude("org.typelevel", "cats-core_2.12"))
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.6.0")
 
 addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 


### PR DESCRIPTION
Expected order is beer, cider, wine, spirits, OFP

<img width="989" alt="ADR-1899 View return duty suspended table" src="https://github.com/user-attachments/assets/a2b65c2f-4a0c-4af2-8c12-1bf8349c6340" />
