### PR TITLE
ADR-1911 Fix flaky DutyCalculationHelperSpec test

### DIFF
--- a/app/controllers/checkAndSubmit/ReturnSubmittedNoDetailsController.scala
+++ b/app/controllers/checkAndSubmit/ReturnSubmittedNoDetailsController.scala
@@ -20,7 +20,7 @@ import config.Constants.{noDetailsValue, returnCreatedDetailsKey}
 import config.FrontendAppConfig
 import controllers.actions._
 import play.api.Logging
-import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import views.html.checkAndSubmit.ReturnSubmittedNoDetailsView

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import uk.gov.hmrc.DefaultBuildSettings
 import uk.gov.hmrc.versioning.SbtGitVersioning.autoImport.majorVersion
 
 ThisBuild / majorVersion := 0
-ThisBuild / scalaVersion := "2.13.14"
+ThisBuild / scalaVersion := "2.13.16"
 
 lazy val appName: String = "alcohol-duty-returns-frontend"
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -8,7 +8,7 @@ object AppDependencies {
 
   val compile = Seq(
     play.sbt.PlayImport.ws,
-    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"     % "11.12.0",
+    "uk.gov.hmrc"       %% "play-frontend-hmrc-play-30"     % "11.13.0",
     "uk.gov.hmrc"       %% "play-conditional-form-mapping-play-30"  % "3.2.0",
     "uk.gov.hmrc"       %% "bootstrap-frontend-play-30"     % bootstrapVersion,
     "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"             % hmrcMongoVersion,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.9.9
+sbt.version=1.10.10
 hmrc-frontend-scaffold.version=0.39.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -12,7 +12,7 @@ addSbtPlugin("org.playframework" % "sbt-plugin" % "3.0.6")
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" exclude("org.scala-lang.modules", "scala-xml_2.12"))
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.3.0")
 
 addSbtPlugin("io.github.irundaia" % "sbt-sassify" % "1.5.2")
 

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -158,11 +158,19 @@ trait ModelGenerators {
     Gen.oneOf(AlcoholType.values)
   }
 
+  val abvRanges = Seq(
+    (AlcoholByVolume(1.3), AlcoholByVolume(3.4)),
+    (AlcoholByVolume(3.5), AlcoholByVolume(5.5)),
+    (AlcoholByVolume(3.5), AlcoholByVolume(8.4)),
+    (AlcoholByVolume(5.6), AlcoholByVolume(8.4)),
+    (AlcoholByVolume(8.5), AlcoholByVolume(22.0))
+  )
+
   implicit val abvIntervalGen: Arbitrary[ABVRange] = Arbitrary {
     (for {
-      label  <- arbitrary[AlcoholType]
-      minABV <- arbitrary[AlcoholByVolume]
-      maxABV <- arbitrary[AlcoholByVolume]
+      label           <- arbitrary[AlcoholType]
+      range           <- Gen.oneOf(abvRanges)
+      (minABV, maxABV) = range
     } yield ABVRange(label, minABV, maxABV)).suchThat(interval => interval.minABV.value < interval.maxABV.value)
   }
 
@@ -183,7 +191,7 @@ trait ModelGenerators {
 
   implicit val arbitraryRateBand: Arbitrary[RateBand] = Arbitrary {
     for {
-      taxType        <- Gen.alphaStr.suchThat(_.nonEmpty)
+      taxType        <- Gen.alphaStr.retryUntil(_.nonEmpty)
       description    <- Gen.alphaStr
       rateType       <- arbitraryRateType.arbitrary
       alcoholRegimes <- arbitrarySetOfAlcoholRegimes.arbitrary
@@ -231,7 +239,7 @@ trait ModelGenerators {
 
   def genRateBandForRegime(alcoholRegime: AlcoholRegime): Gen[RateBand] =
     for {
-      taxType        <- Gen.alphaStr.suchThat(_.nonEmpty)
+      taxType        <- Gen.alphaStr.retryUntil(_.nonEmpty)
       description    <- Gen.alphaStr
       rateType       <- arbitraryRateType.arbitrary
       alcoholRegimes <- genAlcoholRegime(alcoholRegime)
@@ -240,7 +248,15 @@ trait ModelGenerators {
 
   def genRateBandForRegimeWithSPR(alcoholRegime: AlcoholRegime): Gen[RateBand] =
     for {
-      taxType        <- Gen.alphaStr.suchThat(_.nonEmpty)
+      taxType        <- Gen.alphaStr.retryUntil(_.nonEmpty)
+      description    <- Gen.alphaStr
+      rateType       <- arbitraryRateType.arbitrary
+      alcoholRegimes <- genAlcoholRegime(alcoholRegime)
+    } yield RateBand(taxType, description, rateType, None, Set(alcoholRegimes))
+
+  def genSingleUnmatchedRateBandForRegimeWithSPR(alcoholRegime: AlcoholRegime): Gen[RateBand] =
+    for {
+      taxType        <- Gen.oneOf(Seq("123", "124", "125", "126"))
       description    <- Gen.alphaStr
       rateType       <- arbitraryRateType.arbitrary
       alcoholRegimes <- genAlcoholRegime(alcoholRegime)

--- a/test/viewmodels/declareDuty/DutyCalculationHelperSpec.scala
+++ b/test/viewmodels/declareDuty/DutyCalculationHelperSpec.scala
@@ -66,11 +66,11 @@ class DutyCalculationHelperSpec extends SpecBase {
 
       val result = DutyCalculationHelper.dutyDueTableViewModel(alcoholDuty, emptyUserAnswers, regime)(getMessages(app))
 
-      result mustEqual Left("No rate bands found")
+      result mustBe Left("No rate bands found")
     }
 
     "must return a Left with error message when no matching rate band for tax type" in {
-      val unmatchedRateBand = genRateBandForRegimeWithSPR(regime).sample.value
+      val unmatchedRateBand = genSingleUnmatchedRateBandForRegimeWithSPR(regime).sample.value
       val unmatchedTaxType  = genVolumeAndRateByTaxTypeRateBand(unmatchedRateBand).arbitrary.sample.value
       val rateBands         = genListOfRateBandForRegimeWithSPR(regime).sample.value.toSet
       val totalDuty         = unmatchedTaxType.dutyRate * unmatchedTaxType.pureAlcohol


### PR DESCRIPTION
1. Ensure that `unmatchedRateBand` has a different tax type code from those in `rateBands`
- Separate method to generate unmatchedRateBand in which `taxTypeCode` is a string of digits (instead of an alphaStr)
2. Ensure that generators don't produce bad data from which sampling gives `None`: 
- Change `suchThat(_.nonEmpty)` to `retryUntil(_.nonEmpty)` for `taxTypeCode`
- `minABV` and `maxABV` must come from a list of ranges

Test passes when run 50000 times:
<img width="914" alt="ADR-1911 tests passed" src="https://github.com/user-attachments/assets/09ccf26f-082b-40b9-a6b8-02fa4ec605af" />
