### PR TITLE
ADR-1970 Fix flaky ReturnPeriodSpec test

### DIFF
--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -219,8 +219,7 @@ trait ModelGenerators {
   } yield s"${year}A${(month + 'A').toChar}"
 
   def invalidPeriodKeyGen: Gen[String] = Gen.alphaStr
-    .suchThat(_.nonEmpty)
-    .suchThat(!_.matches(ReturnPeriod.returnPeriodPattern.toString()))
+    .retryUntil(s => s.nonEmpty && !s.matches(ReturnPeriod.returnPeriodPattern.toString))
 
   def returnPeriodGen: Gen[ReturnPeriod] = periodKeyGen.map(ReturnPeriod.fromPeriodKey(_).get)
 


### PR DESCRIPTION
Change suchThat to returnUntil in invalidPeriodKeyGen so that sampling from it can't return None

Test passes when running 10000 times:
<img width="560" alt="ADR-1970 tests passed" src="https://github.com/user-attachments/assets/2a80f629-7162-467e-a714-7e85b92c43cf" />
