### PR TITLE
ADR-1996 Prevent pre-population of multiple SPR form

### DIFF
--- a/app/controllers/declareDuty/MultipleSPRListController.scala
+++ b/app/controllers/declareDuty/MultipleSPRListController.scala
@@ -22,7 +22,7 @@ import forms.declareDuty.MultipleSPRListFormProvider
 import javax.inject.Inject
 import models.{AlcoholRegime, NormalMode}
 import navigation.ReturnsNavigator
-import pages.declareDuty.DoYouWantToAddMultipleSPRToListPage
+import pages.declareDuty.{DoYouWantToAddMultipleSPRToListPage, TellUsAboutMultipleSPRRatePage}
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import connectors.UserAnswersConnector
@@ -85,11 +85,13 @@ class MultipleSPRListController @Inject() (
               ),
           value =>
             for {
-              updatedAnswers <-
+              updatedUserAnswers <-
                 Future.fromTry(request.userAnswers.setByKey(DoYouWantToAddMultipleSPRToListPage, regime, value))
-              _              <- userAnswersConnector.set(updatedAnswers)
+              cleanedUserAnswers <-
+                Future.fromTry(updatedUserAnswers.removeByKey(TellUsAboutMultipleSPRRatePage, regime))
+              _                  <- userAnswersConnector.set(cleanedUserAnswers)
             } yield Redirect(
-              navigator.nextPageWithRegime(DoYouWantToAddMultipleSPRToListPage, NormalMode, updatedAnswers, regime)
+              navigator.nextPageWithRegime(DoYouWantToAddMultipleSPRToListPage, NormalMode, cleanedUserAnswers, regime)
             )
         )
     }


### PR DESCRIPTION
Clear TellUsAboutMultipleSPRRatePage in MultipleSPRListController.onSubmit() in the same way as CheckYourAnswersSPRController, in case the user has arrived at the multiple SPR list page from 'Change' but without changing any values