### PR TITLE
ADR-1965 Live Service Checklist - remove logic from views

### DIFF
--- a/app/controllers/adjustment/AdjustmentListController.scala
+++ b/app/controllers/adjustment/AdjustmentListController.scala
@@ -29,7 +29,7 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import viewmodels.checkAnswers.adjustment.{AdjustmentListSummaryHelper, AdjustmentOverUnderDeclarationCalculationHelper}
 import play.api.Logging
-import viewmodels.PaginatedViewModel
+import viewmodels.{PaginatedViewModel, PaginationViewModel}
 
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
@@ -72,7 +72,17 @@ class AdjustmentListController @Inject() (
             for {
               updatedAnswers <- Future.fromTry(request.userAnswers.set(AdjustmentTotalPage, total.duty))
               _              <- userAnswersConnector.set(updatedAnswers)
-            } yield Ok(view(preparedForm, paginatedViewModel.tableViewModel, paginatedViewModel.totalPages, pageNumber))
+            } yield Ok(
+              view(
+                preparedForm,
+                paginatedViewModel.tableViewModel,
+                PaginationViewModel(
+                  paginatedViewModel.totalPages,
+                  pageNumber,
+                  controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
+                )
+              )
+            )
           }
         }
         .recover { case _ =>
@@ -92,7 +102,15 @@ class AdjustmentListController @Inject() (
           formWithErrors =>
             Future.successful(
               BadRequest(
-                view(formWithErrors, paginatedViewModel.tableViewModel, paginatedViewModel.totalPages, pageNumber)
+                view(
+                  formWithErrors,
+                  paginatedViewModel.tableViewModel,
+                  PaginationViewModel(
+                    paginatedViewModel.totalPages,
+                    pageNumber,
+                    controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
+                  )
+                )
               )
             ),
           value =>

--- a/app/controllers/adjustment/SpoiltAlcoholicProductTypeController.scala
+++ b/app/controllers/adjustment/SpoiltAlcoholicProductTypeController.scala
@@ -59,7 +59,7 @@ class SpoiltAlcoholicProductTypeController @Inject() (
       case Some(regime) => form.fill(regime.entryName)
     }
 
-    Ok(view(preparedForm, mode, request.userAnswers.regimes))
+    Ok(view(preparedForm, mode, helper.getViewModel(request.userAnswers.regimes)))
   }
 
   def onSubmit(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData).async {
@@ -67,7 +67,8 @@ class SpoiltAlcoholicProductTypeController @Inject() (
       form
         .bindFromRequest()
         .fold(
-          formWithErrors => Future.successful(BadRequest(view(formWithErrors, mode, request.userAnswers.regimes))),
+          formWithErrors =>
+            Future.successful(BadRequest(view(formWithErrors, mode, helper.getViewModel(request.userAnswers.regimes)))),
           value =>
             AlcoholRegime.fromString(value) match {
               case Some(regime) =>
@@ -95,7 +96,7 @@ class SpoiltAlcoholicProductTypeController @Inject() (
         )
   }
 
-  def updateAlcoholicProductType(
+  private def updateAlcoholicProductType(
     adjustmentEntry: AdjustmentEntry,
     currentValue: AlcoholRegime
   ): (AdjustmentEntry, Boolean) =

--- a/app/controllers/adjustment/WhenDidYouPayDutyController.scala
+++ b/app/controllers/adjustment/WhenDidYouPayDutyController.scala
@@ -30,6 +30,7 @@ import connectors.UserAnswersConnector
 import models.adjustment.AdjustmentEntry
 import play.api.Logging
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import viewmodels.adjustment.WhenDidYouPayDutyHelper
 import views.html.adjustment.WhenDidYouPayDutyView
 
 import java.time.YearMonth
@@ -43,6 +44,7 @@ class WhenDidYouPayDutyController @Inject() (
   getData: DataRetrievalAction,
   requireData: DataRequiredAction,
   formProvider: WhenDidYouPayDutyFormProvider,
+  helper: WhenDidYouPayDutyHelper,
   appConfig: FrontendAppConfig,
   val controllerComponents: MessagesControllerComponents,
   view: WhenDidYouPayDutyView
@@ -57,23 +59,11 @@ class WhenDidYouPayDutyController @Inject() (
     request.userAnswers.get(CurrentAdjustmentEntryPage) match {
       case Some(AdjustmentEntry(_, Some(adjustmentType), Some(period), _, _, _, _, _, _, _, _, _, _)) =>
         Ok(
-          view(
-            form.fill(
-              period
-            ),
-            mode,
-            adjustmentType,
-            appConfig.exciseEnquiriesUrl
-          )
+          view(form.fill(period), mode, helper.createViewModel(adjustmentType))
         )
       case Some(AdjustmentEntry(_, Some(adjustmentType), _, _, _, _, _, _, _, _, _, _, _))            =>
         Ok(
-          view(
-            form,
-            mode,
-            adjustmentType,
-            appConfig.exciseEnquiriesUrl
-          )
+          view(form, mode, helper.createViewModel(adjustmentType))
         )
       case _                                                                                          =>
         logger.warn("Couldn't fetch the adjustmentType and period in AdjustmentEntry from user answers")
@@ -92,14 +82,7 @@ class WhenDidYouPayDutyController @Inject() (
             request.userAnswers.get(CurrentAdjustmentEntryPage) match {
               case Some(AdjustmentEntry(_, Some(adjustmentType), _, _, _, _, _, _, _, _, _, _, _)) =>
                 Future.successful(
-                  BadRequest(
-                    view(
-                      formWithErrors,
-                      mode,
-                      adjustmentType,
-                      appConfig.exciseEnquiriesUrl
-                    )
-                  )
+                  BadRequest(view(formWithErrors, mode, helper.createViewModel(adjustmentType)))
                 )
               case _                                                                               =>
                 logger.warn("Couldn't fetch the adjustmentType in AdjustmentEntry from user answers")

--- a/app/models/adjustment/AdjustmentType.scala
+++ b/app/models/adjustment/AdjustmentType.scala
@@ -22,6 +22,8 @@ import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 
+import scala.collection.immutable.Seq
+
 sealed trait AdjustmentType
 
 object AdjustmentType extends Enumerable.Implicits {
@@ -48,6 +50,9 @@ object AdjustmentType extends Enumerable.Implicits {
       hint = Some(Hint(content = Text(messages(s"adjustmentType.${value.toString}.hint"))))
     )
   }
+
+  def getErrorLinkOverride(implicit messages: Messages): String =
+    adjustmentTypeOptions.headOption.flatMap(_.id).getOrElse("")
 
   implicit val enumerable: Enumerable[AdjustmentType] =
     Enumerable(values.map(v => v.toString -> v): _*)

--- a/app/models/adjustment/AdjustmentType.scala
+++ b/app/models/adjustment/AdjustmentType.scala
@@ -51,7 +51,7 @@ object AdjustmentType extends Enumerable.Implicits {
     )
   }
 
-  def getErrorLinkOverride(implicit messages: Messages): String =
+  def getTopRadioId(implicit messages: Messages): String =
     adjustmentTypeOptions.headOption.flatMap(_.id).getOrElse("")
 
   implicit val enumerable: Enumerable[AdjustmentType] =

--- a/app/viewmodels/PaginationViewModel.scala
+++ b/app/viewmodels/PaginationViewModel.scala
@@ -35,6 +35,8 @@ case class PaginationViewModel(
         )
       })
     )
+
+  val isMoreThanOnePage: Boolean = totalPages > 1
 }
 
 case class PaginatedViewModel(totalPages: Int, tableViewModel: TableViewModel)

--- a/app/viewmodels/adjustment/SpoiltAlcoholicProductTypeViewModel.scala
+++ b/app/viewmodels/adjustment/SpoiltAlcoholicProductTypeViewModel.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.adjustment
+
+import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+
+case class SpoiltAlcoholicProductTypeViewModel(radioOptions: Seq[RadioItem]) {
+
+  val getTopRadioId: String = radioOptions.headOption.flatMap(_.id).getOrElse("")
+
+}

--- a/app/viewmodels/adjustment/WhenDidYouPayDutyHelper.scala
+++ b/app/viewmodels/adjustment/WhenDidYouPayDutyHelper.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.adjustment
+
+import config.FrontendAppConfig
+import models.adjustment.AdjustmentType
+import models.adjustment.AdjustmentType._
+import play.api.i18n.Messages
+
+import javax.inject.Inject
+
+case class WhenDidYouPayDutyViewModel(adjustmentType: AdjustmentType, exciseEnquiriesUrl: String) {
+
+  def getHeading(implicit messages: Messages): String =
+    if (adjustmentType == Underdeclaration) {
+      messages("whenDidYouPayDuty.under-declaration.title")
+    } else if (adjustmentType == Spoilt) {
+      throw new IllegalArgumentException("Not expecting WhenDidYouPayDuty to be asked for Spoilt")
+    } else {
+      messages("whenDidYouPayDuty.default.title")
+    }
+
+}
+
+class WhenDidYouPayDutyHelper @Inject() (appConfig: FrontendAppConfig) {
+
+  def createViewModel(adjustmentType: AdjustmentType): WhenDidYouPayDutyViewModel =
+    WhenDidYouPayDutyViewModel(adjustmentType = adjustmentType, exciseEnquiriesUrl = appConfig.exciseEnquiriesUrl)
+
+}

--- a/app/viewmodels/checkAnswers/adjustment/SpoiltAlcoholicProductTypeHelper.scala
+++ b/app/viewmodels/checkAnswers/adjustment/SpoiltAlcoholicProductTypeHelper.scala
@@ -25,6 +25,7 @@ import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 import viewmodels.AlcoholRegimesViewOrder.regimesInViewOrder
+import viewmodels.adjustment.SpoiltAlcoholicProductTypeViewModel
 
 import javax.inject.Inject
 
@@ -53,7 +54,7 @@ class SpoiltAlcoholicProductTypeHelper @Inject() (
     )
   }
 
-  def radioOptions(regimes: AlcoholRegimes)(implicit messages: Messages): Seq[RadioItem] =
+  private def radioOptions(regimes: AlcoholRegimes)(implicit messages: Messages): Seq[RadioItem] =
     regimesInViewOrder(regimes).map { regime =>
       val regimeName = regime.entryName
 
@@ -63,4 +64,7 @@ class SpoiltAlcoholicProductTypeHelper @Inject() (
         id = Some(regimeName)
       )
     }
+
+  def getViewModel(regimes: AlcoholRegimes)(implicit messages: Messages): SpoiltAlcoholicProductTypeViewModel =
+    SpoiltAlcoholicProductTypeViewModel(radioOptions(regimes))
 }

--- a/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
+++ b/app/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnHelper.scala
@@ -44,7 +44,20 @@ case class DutyDueForThisReturnViewModel(
   dutiesBreakdownSummaryList: SummaryList,
   youveAlsoDeclaredSummaryList: SummaryList,
   totalDue: BigDecimal
-)
+) {
+  def getTitle(implicit messages: Messages): String =
+    if (isTotalDueZero) {
+      messages("dutyDueForThisReturn.nil.title")
+    } else {
+      messages("dutyDueForThisReturn.title", messages("site.currency.2DP", totalDue))
+    }
+
+  val isTotalDueZero: Boolean = totalDue == 0
+
+  val isTotalDueAboveZero: Boolean = totalDue > 0
+
+  val isTotalDueBelowZero: Boolean = totalDue < 0
+}
 
 class DutyDueForThisReturnHelper @Inject() (
   calculatorConnector: AlcoholDutyCalculatorConnector,

--- a/app/views/adjustment/AdjustmentDutyDueView.scala.html
+++ b/app/views/adjustment/AdjustmentDutyDueView.scala.html
@@ -14,9 +14,8 @@
  * limitations under the License.
  *@
 
-@import components.{Caption, PageHeading, PageHeadingWithMonetaryValue, Paragraph, BulletList}
+@import components.{BulletList, Caption, PageHeading, PageHeadingWithMonetaryValue, Paragraph}
 @import models.adjustment.AdjustmentType
-@import models.adjustment.AdjustmentType.RepackagedDraughtProducts
 @import viewmodels.Money
 @import viewmodels.checkAnswers.adjustment.AdjustmentDutyDueViewModel
 
@@ -51,7 +50,7 @@
 
     @govukButton(
         ButtonViewModel("continueButton", messages("site.continue"))
-        .asLink(controllers.adjustment.routes.CheckYourAnswersController.onPageLoad().url)
+                .asLink(controllers.adjustment.routes.CheckYourAnswersController.onPageLoad().url)
     )
 
-}@import views.html.components.PageHeadingWithMonetaryValue
+}

--- a/app/views/adjustment/AdjustmentListView.scala.html
+++ b/app/views/adjustment/AdjustmentListView.scala.html
@@ -19,78 +19,76 @@
 @import viewmodels.{TableViewModel, PaginationViewModel}
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukRadios: GovukRadios,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    govukTable: GovukTable,
-    tableRowActionList: components.TableRowActionList,
-    tableRowAction: components.TableRowAction,
-    govukPagination: GovukPagination,
-    govukSummaryList : GovukSummaryList
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios: GovukRadios,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        govukTable: GovukTable,
+        tableRowActionList: components.TableRowActionList,
+        tableRowAction: components.TableRowAction,
+        govukPagination: GovukPagination,
+        govukSummaryList: GovukSummaryList
 )
 
 
-@(form: Form[_], adjustmentTable:TableViewModel, totalPages: Int, currentPage: Int)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], adjustmentTable: TableViewModel, paginationViewModel: PaginationViewModel)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("adjustmentList.title")), showBackLink = false, fullWidth = true) {
 
-    @formHelper(action = controllers.adjustment.routes.AdjustmentListController.onSubmit(currentPage), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.adjustment.routes.AdjustmentListController.onSubmit(paginationViewModel.currentPage), Symbol("autoComplete") -> "off") {
 
-    @if(form.errors.nonEmpty) {
-        @govukErrorSummary(ErrorSummaryViewModel(form))
-    }
-
-    @caption(
-        id = "adjustment-list-section",
-        text = messages("section.alcoholDutyReturn"),
-    )
-
-    @pageHeading(messages("adjustmentList.heading"))
-
-    @govukTable(Table(
-        head = Some(adjustmentTable.head),
-        rows = adjustmentTable.rows.map(row => {
-            val actions = TableRow(content = HtmlContent(tableRowActionList(
-            id = "adjustmentList",
-            actions = row.actions.map(action => tableRowAction(
-            id = "",
-            text = action.label,
-            href = action.href,
-            visuallyHiddenContent = action.visuallyHiddenText
-            )
-            ))))
-            row.cells :+ actions
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
         }
-        ))
-    )
 
-    @if(totalPages > 1) {
-        @govukPagination(
-            PaginationViewModel(
-                currentPage = currentPage,
-                totalPages = totalPages,
-                baseUrl = controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
-                    ).paginate
-                )
-    }
-
-    @{adjustmentTable.total.map { totalSummaryList =>
-        govukSummaryList(totalSummaryList)
-    }}
-
-    @govukRadios(
-        RadiosViewModel.yesNo(
-        field = form("adjustment-list-yes-no-value"),
-        legend = LegendViewModel(messages("adjustmentList.question")).withCssClass(Css.fieldsetLegendLCssClass)
+        @caption(
+            id = "adjustment-list-section",
+            text = messages("section.alcoholDutyReturn"),
         )
-    )
 
-    @govukButton(
-        ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
-    )
+        @pageHeading(messages("adjustmentList.heading"))
+
+        @govukTable(Table(
+            head = Some(adjustmentTable.head),
+            rows = adjustmentTable.rows.map(row => {
+                val actions = TableRow(content = HtmlContent(tableRowActionList(
+                    id = "adjustmentList",
+                    actions = row.actions.map(action => tableRowAction(
+                        id = "",
+                        text = action.label,
+                        href = action.href,
+                        visuallyHiddenContent = action.visuallyHiddenText
+                    )
+                    ))))
+                row.cells :+ actions
+            }
+            ))
+        )
+
+        @if(paginationViewModel.isMoreThanOnePage) {
+            @govukPagination(
+                paginationViewModel.paginate
+            )
+        }
+
+        @{
+            adjustmentTable.total.map { totalSummaryList =>
+                govukSummaryList(totalSummaryList)
+            }
+        }
+
+        @govukRadios(
+            RadiosViewModel.yesNo(
+                field = form("adjustment-list-yes-no-value"),
+                legend = LegendViewModel(messages("adjustmentList.question")).withCssClass(Css.fieldsetLegendLCssClass)
+            )
+        )
+
+        @govukButton(
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+        )
     }
 }

--- a/app/views/adjustment/AdjustmentRepackagedTaxTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentRepackagedTaxTypeView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading}
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/AdjustmentRepackagedTaxTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentRepackagedTaxTypeView.scala.html
@@ -1,31 +1,30 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading}
 @import models.adjustment.AdjustmentType
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    pageHeading: PageHeading,
-    caption: Caption
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        pageHeading: PageHeading,
+        caption: Caption
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType)(implicit request: Request[_], messages: Messages)
@@ -50,14 +49,14 @@
                 field = form("new-tax-type-code"),
                 label = LabelViewModel(messages("adjustmentRepackagedTaxType.heading")).asVisuallyHidden()
             )
-            .asNumeric()
-            .withWidth(Fixed10)
-            .withHint(HintViewModel(
-            messages("adjustmentRepackagedTaxType.hint")
+                    .asNumeric()
+                    .withWidth(Fixed10)
+                    .withHint(HintViewModel(
+                messages("adjustmentRepackagedTaxType.hint")
             )))
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.continue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.continue"))
         )
     }
 }

--- a/app/views/adjustment/AdjustmentSmallProducerReliefDutyRateView.scala.html
+++ b/app/views/adjustment/AdjustmentSmallProducerReliefDutyRateView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading, Link, Paragraph, FormGroupWithError}
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/AdjustmentSmallProducerReliefDutyRateView.scala.html
+++ b/app/views/adjustment/AdjustmentSmallProducerReliefDutyRateView.scala.html
@@ -1,34 +1,33 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading, Link, Paragraph, FormGroupWithError}
 @import models.adjustment.AdjustmentType
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    link: Link,
-    paragraph: Paragraph,
-    pageHeading: PageHeading,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        link: Link,
+        paragraph: Paragraph,
+        pageHeading: PageHeading,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType)(implicit request: Request[_], messages: Messages)
@@ -42,27 +41,27 @@
         }
 
         @caption(
-        id = "adjustment-small-producer-relief-duty-rate-section",
-        text = messages(s"section.adjustment.$adjustmentType"),
+            id = "adjustment-small-producer-relief-duty-rate-section",
+            text = messages(s"section.adjustment.$adjustmentType"),
         )
 
-        @formGroupWithError(form.errors.nonEmpty){
-                @pageHeading(messages("adjustmentSmallProducerReliefDutyRate.heading"))
+        @formGroupWithError(form.errors.nonEmpty) {
+            @pageHeading(messages("adjustmentSmallProducerReliefDutyRate.heading"))
 
-                 @govukInput(
-                    InputViewModel(
-                        field = form("adjustment-small-producer-relief-duty-rate-input"),
-                        label = LabelViewModel(messages("adjustmentSmallProducerReliefDutyRate.heading")).asVisuallyHidden()
-                    )
-                    .asNumeric()
-                    .withWidth(Fixed10)
-                    .withPoundPrefix
-                    .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
+            @govukInput(
+                InputViewModel(
+                    field = form("adjustment-small-producer-relief-duty-rate-input"),
+                    label = LabelViewModel(messages("adjustmentSmallProducerReliefDutyRate.heading")).asVisuallyHidden()
                 )
+                        .asNumeric()
+                        .withWidth(Fixed10)
+                        .withPoundPrefix
+                        .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
+            )
         }
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
     }
 }

--- a/app/views/adjustment/AdjustmentTaxTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentTaxTypeView.scala.html
@@ -1,39 +1,38 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading, FormGroupWithError}
 @import models.adjustment.AdjustmentType
 @import models.adjustment.AdjustmentType.{Underdeclaration, RepackagedDraughtProducts}
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType)(implicit request: Request[_], messages: Messages)
 
 @titleContent = @{
-    if(adjustmentType == RepackagedDraughtProducts){
+    if(adjustmentType == RepackagedDraughtProducts) {
         messages("adjustmentTaxType.repackaged.title")
     } else {
         messages("adjustmentTaxType.title")
@@ -52,29 +51,29 @@
             id = "adjustment-tax-type-section",
             text = messages(s"section.adjustment.$adjustmentType")
         )
-        @formGroupWithError(form.errors.nonEmpty){
-                @pageHeading(titleContent)
+        @formGroupWithError(form.errors.nonEmpty) {
+            @pageHeading(titleContent)
 
-                @govukInput(
-                    InputViewModel(
-                        field = form("adjustment-tax-type-input"),
-                        label = if (adjustmentType == RepackagedDraughtProducts)
+            @govukInput(
+                InputViewModel(
+                    field = form("adjustment-tax-type-input"),
+                    label = if(adjustmentType == RepackagedDraughtProducts)
                         LabelViewModel(messages("adjustmentTaxType.repackaged.heading")).asVisuallyHidden()
-                        else
+                    else
                         LabelViewModel(messages("adjustmentTaxType.heading")).asVisuallyHidden()
-                    )
-                    .asNumeric()
-                    .withWidth(Fixed10)
-                    .withHint(HintViewModel(
-                    if(adjustmentType == Underdeclaration){
-                    messages("adjustmentTaxType.underDeclaration.hint")
+                )
+                        .asNumeric()
+                        .withWidth(Fixed10)
+                        .withHint(HintViewModel(
+                    if(adjustmentType == Underdeclaration) {
+                        messages("adjustmentTaxType.underDeclaration.hint")
                     } else {
-                    messages("adjustmentTaxType.default.hint")
+                        messages("adjustmentTaxType.default.hint")
                     }
-                    )))
+                )))
         }
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
     }
 }

--- a/app/views/adjustment/AdjustmentTaxTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentTaxTypeView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import viewmodels.InputWidth._
 @import components.{Caption, PageHeading, FormGroupWithError}
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/AdjustmentTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentTypeView.scala.html
@@ -33,7 +33,7 @@
     @formHelper(action = controllers.adjustment.routes.AdjustmentTypeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("adjustment-type-value" -> AdjustmentType.adjustmentTypeOptions.headOption.flatMap(_.id).getOrElse(""))))
+            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("adjustment-type-value" -> AdjustmentType.getErrorLinkOverride)))
         }
 
         @caption(

--- a/app/views/adjustment/AdjustmentTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentTypeView.scala.html
@@ -34,7 +34,6 @@
 
         @if(form.errors.nonEmpty) {
             @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("adjustment-type-value" -> AdjustmentType.adjustmentTypeOptions.headOption.flatMap(_.id).getOrElse(""))))
-
         }
 
         @caption(

--- a/app/views/adjustment/AdjustmentTypeView.scala.html
+++ b/app/views/adjustment/AdjustmentTypeView.scala.html
@@ -33,7 +33,7 @@
     @formHelper(action = controllers.adjustment.routes.AdjustmentTypeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("adjustment-type-value" -> AdjustmentType.getErrorLinkOverride)))
+            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("adjustment-type-value" -> AdjustmentType.getTopRadioId)))
         }
 
         @caption(

--- a/app/views/adjustment/AdjustmentVolumeView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
@@ -34,59 +33,59 @@
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType, regime: AlcoholRegime, rateBandContent: String)(implicit request: Request[_], messages: Messages)
 
-    @layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
+@layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
 
-        @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-            @if(form.errors.nonEmpty) {
-                @govukErrorSummary(ErrorSummaryViewModel(form))
-            }
-
-            @caption(
-                id = "adjustment-volume-section",
-                text = messages(s"section.adjustment.$adjustmentType"),
-            )
-
-            @pageHeading(messages("adjustmentVolume.heading"))
-
-            @govukFieldset(Fieldset(
-                legend = Some(Legend(
-                    content = Text(rateBandContent),
-                    classes = Css.fieldsetLegendSCssClass
-                )),
-                html = HtmlFormat.fill(List(
-                    govukInput(
-                        InputViewModel(
-                            field = form("volumes"),
-                            key = "totalLitresVolume",
-                            label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
-                            errorMessageField = form("volumes_totalLitresVolume"),
-                            value = form("volumes.totalLitresVolume").value
-                        )
-                                .asNumeric()
-                                .withWidth(Fixed10)
-                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-                                .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
-                    ),
-
-                    govukInput(
-                        InputViewModel(
-                            field = form("volumes"),
-                            key = "pureAlcoholVolume",
-                            label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
-                            errorMessageField = form("volumes_pureAlcoholVolume"),
-                            value = form("volumes.pureAlcoholVolume").value
-                        )
-                                .asNumeric()
-                                .withWidth(Fixed10)
-                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-                                .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
-                    )
-                ))
-            ))
-
-            @govukButton(
-                ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
-            )
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
         }
+
+        @caption(
+            id = "adjustment-volume-section",
+            text = messages(s"section.adjustment.$adjustmentType"),
+        )
+
+        @pageHeading(messages("adjustmentVolume.heading"))
+
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(rateBandContent),
+                classes = Css.fieldsetLegendSCssClass
+            )),
+            html = HtmlFormat.fill(List(
+                govukInput(
+                    InputViewModel(
+                        field = form("volumes"),
+                        key = "totalLitresVolume",
+                        label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
+                        errorMessageField = form("volumes_totalLitresVolume"),
+                        value = form("volumes.totalLitresVolume").value
+                    )
+                            .asNumeric()
+                            .withWidth(Fixed10)
+                            .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                            .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
+                ),
+
+                govukInput(
+                    InputViewModel(
+                        field = form("volumes"),
+                        key = "pureAlcoholVolume",
+                        label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
+                        errorMessageField = form("volumes_pureAlcoholVolume"),
+                        value = form("volumes.pureAlcoholVolume").value
+                    )
+                            .asNumeric()
+                            .withWidth(Fixed10)
+                            .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                            .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
+                )
+            ))
+        ))
+
+        @govukButton(
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+        )
     }
+}

--- a/app/views/adjustment/AdjustmentVolumeView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeView.scala.html
@@ -1,92 +1,91 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
 @import viewmodels.InputWidth._
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    paragraph: Paragraph,
-    subHeading: SubHeading,
-    govukFieldset: GovukFieldset
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        paragraph: Paragraph,
+        subHeading: SubHeading,
+        govukFieldset: GovukFieldset
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType, regime: AlcoholRegime, rateBandContent: String)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
+    @layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
 
-    @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+        @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-        @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form))
-        }
+            @if(form.errors.nonEmpty) {
+                @govukErrorSummary(ErrorSummaryViewModel(form))
+            }
 
-        @caption(
-            id = "adjustment-volume-section",
-            text = messages(s"section.adjustment.$adjustmentType"),
-        )
-
-        @pageHeading(messages("adjustmentVolume.heading"))
-
-        @govukFieldset(Fieldset(
-          legend = Some(Legend(
-            content = Text(rateBandContent),
-            classes = Css.fieldsetLegendSCssClass
-          )),
-          html = HtmlFormat.fill(List(
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key="totalLitresVolume",
-                label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
-                errorMessageField = form("volumes_totalLitresVolume"),
-                value = form("volumes.totalLitresVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
-            ),
-
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key="pureAlcoholVolume",
-                label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
-                errorMessageField = form("volumes_pureAlcoholVolume"),
-                value = form("volumes.pureAlcoholVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
+            @caption(
+                id = "adjustment-volume-section",
+                text = messages(s"section.adjustment.$adjustmentType"),
             )
-          ))
-        ))
 
-        @govukButton(
-            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
-        )
+            @pageHeading(messages("adjustmentVolume.heading"))
+
+            @govukFieldset(Fieldset(
+                legend = Some(Legend(
+                    content = Text(rateBandContent),
+                    classes = Css.fieldsetLegendSCssClass
+                )),
+                html = HtmlFormat.fill(List(
+                    govukInput(
+                        InputViewModel(
+                            field = form("volumes"),
+                            key = "totalLitresVolume",
+                            label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
+                            errorMessageField = form("volumes_totalLitresVolume"),
+                            value = form("volumes.totalLitresVolume").value
+                        )
+                                .asNumeric()
+                                .withWidth(Fixed10)
+                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                                .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
+                    ),
+
+                    govukInput(
+                        InputViewModel(
+                            field = form("volumes"),
+                            key = "pureAlcoholVolume",
+                            label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
+                            errorMessageField = form("volumes_pureAlcoholVolume"),
+                            value = form("volumes.pureAlcoholVolume").value
+                        )
+                                .asNumeric()
+                                .withWidth(Fixed10)
+                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                                .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
+                    )
+                ))
+            ))
+
+            @govukButton(
+                ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+            )
+        }
     }
-}

--- a/app/views/adjustment/AdjustmentVolumeView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
@@ -1,106 +1,105 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
 @import viewmodels.InputWidth._
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    paragraph: Paragraph,
-    subHeading: SubHeading,
-    govukFieldset: GovukFieldset
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        paragraph: Paragraph,
+        subHeading: SubHeading,
+        govukFieldset: GovukFieldset
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType, regime: AlcoholRegime, rateBandContent: String)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
+    @layout(pageTitle = title(form, messages("adjustmentVolume.title"))) {
 
-    @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeWithSPRController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+        @formHelper(action = controllers.adjustment.routes.AdjustmentVolumeWithSPRController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-        @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form))
-        }
+            @if(form.errors.nonEmpty) {
+                @govukErrorSummary(ErrorSummaryViewModel(form))
+            }
 
-        @caption(
-            id = "how-much-do-you-need-to-adjust-section",
-            text = messages(s"section.adjustment.$adjustmentType"),
-        )
-
-        @pageHeading(messages("adjustmentVolume.heading"))
-
-        @govukFieldset(Fieldset(
-          legend = Some(Legend(
-            content = Text(rateBandContent),
-            classes = Css.fieldsetLegendSCssClass
-          )),
-          html = HtmlFormat.fill(List(
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key = "totalLitresVolume",
-                label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
-                errorMessageField = form("volumes_totalLitresVolume"),
-                value = form("volumes.totalLitresVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
-            ),
-
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key = "pureAlcoholVolume",
-                label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
-                errorMessageField = form("volumes_pureAlcoholVolume"),
-                value = form("volumes.pureAlcoholVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
-            ),
-
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key = "sprDutyRate",
-                label = LabelViewModel(messages("adjustmentVolume.smallProducerReliefDutyRate.heading")),
-                errorMessageField = form("volumes_sprDutyRate"),
-                value = form("volumes.sprDutyRate").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withPoundPrefix
-              .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
+            @caption(
+                id = "how-much-do-you-need-to-adjust-section",
+                text = messages(s"section.adjustment.$adjustmentType"),
             )
-          ))
-        ))
 
-        @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
-        )
+            @pageHeading(messages("adjustmentVolume.heading"))
+
+            @govukFieldset(Fieldset(
+                legend = Some(Legend(
+                    content = Text(rateBandContent),
+                    classes = Css.fieldsetLegendSCssClass
+                )),
+                html = HtmlFormat.fill(List(
+                    govukInput(
+                        InputViewModel(
+                            field = form("volumes"),
+                            key = "totalLitresVolume",
+                            label = LabelViewModel(messages("adjustmentVolume.totalLitresVolume.heading")),
+                            errorMessageField = form("volumes_totalLitresVolume"),
+                            value = form("volumes.totalLitresVolume").value
+                        )
+                                .asNumeric()
+                                .withWidth(Fixed10)
+                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                                .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
+                    ),
+
+                    govukInput(
+                        InputViewModel(
+                            field = form("volumes"),
+                            key = "pureAlcoholVolume",
+                            label = LabelViewModel(messages("adjustmentVolume.pureAlcoholVolume.heading")),
+                            errorMessageField = form("volumes_pureAlcoholVolume"),
+                            value = form("volumes.pureAlcoholVolume").value
+                        )
+                                .asNumeric()
+                                .withWidth(Fixed10)
+                                .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                                .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
+                    ),
+
+                    govukInput(
+                        InputViewModel(
+                            field = form("volumes"),
+                            key = "sprDutyRate",
+                            label = LabelViewModel(messages("adjustmentVolume.smallProducerReliefDutyRate.heading")),
+                            errorMessageField = form("volumes_sprDutyRate"),
+                            value = form("volumes.sprDutyRate").value
+                        )
+                                .asNumeric()
+                                .withWidth(Fixed10)
+                                .withPoundPrefix
+                                .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
+                    )
+                ))
+            ))
+
+            @govukButton(
+                ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+            )
+        }
     }
-}

--- a/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
+++ b/app/views/adjustment/AdjustmentVolumeWithSPRView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/CheckYourAnswersView.scala.html
+++ b/app/views/adjustment/CheckYourAnswersView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
@@ -29,22 +30,22 @@
 
 @(list: SummaryList)(implicit request: Request[_], messages: Messages)
 
-    @layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
-        @formHelper(action = controllers.adjustment.routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "off") {
+@layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
+    @formHelper(action = controllers.adjustment.routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "off") {
 
-            @caption(
-                id = "check-your-answers-section",
-                text = messages("section.adjustment.checkAnswers"),
-            )
+        @caption(
+            id = "check-your-answers-section",
+            text = messages("section.adjustment.checkAnswers"),
+        )
 
-            @pageHeading(messages("checkYourAnswers.heading"))
+        @pageHeading(messages("checkYourAnswers.heading"))
 
-            @subHeading(messages("checkYourAnswers.subHeading"), Css.headingLCssClass)
+        @subHeading(messages("checkYourAnswers.subHeading"), Css.headingLCssClass)
 
-            @govukSummaryList(list)
+        @govukSummaryList(list)
 
-            @govukButton(
-                ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
-            )
-        }
+        @govukButton(
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+        )
     }
+}

--- a/app/views/adjustment/CheckYourAnswersView.scala.html
+++ b/app/views/adjustment/CheckYourAnswersView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/CheckYourAnswersView.scala.html
+++ b/app/views/adjustment/CheckYourAnswersView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/CheckYourAnswersView.scala.html
+++ b/app/views/adjustment/CheckYourAnswersView.scala.html
@@ -1,51 +1,50 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, SubHeading}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukSummaryList: GovukSummaryList,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    subHeading: SubHeading
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukSummaryList: GovukSummaryList,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        subHeading: SubHeading
 )
 
 @(list: SummaryList)(implicit request: Request[_], messages: Messages)
 
-@layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
-     @formHelper(action = controllers.adjustment.routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "off") {
+    @layout(pageTitle = titleNoForm(messages("checkYourAnswers.title"))) {
+        @formHelper(action = controllers.adjustment.routes.CheckYourAnswersController.onSubmit(), Symbol("autoComplete") -> "off") {
 
-         @caption(
-             id = "check-your-answers-section",
-             text = messages("section.adjustment.checkAnswers"),
-         )
+            @caption(
+                id = "check-your-answers-section",
+                text = messages("section.adjustment.checkAnswers"),
+            )
 
-         @pageHeading(messages("checkYourAnswers.heading"))
+            @pageHeading(messages("checkYourAnswers.heading"))
 
-         @subHeading(messages("checkYourAnswers.subHeading"), Css.headingLCssClass)
+            @subHeading(messages("checkYourAnswers.subHeading"), Css.headingLCssClass)
 
-         @govukSummaryList(list)
+            @govukSummaryList(list)
 
-         @govukButton(
-             ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
-         )
-     }
-}
+            @govukButton(
+                ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
+            )
+        }
+    }

--- a/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
+++ b/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, SubHeading, PageHeading, Paragraph, BulletList, FormGroupWithError}
 @import config.Constants.Css
 

--- a/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
+++ b/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
@@ -1,81 +1,80 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, SubHeading, PageHeading, Paragraph, BulletList, FormGroupWithError}
 @import config.Constants.Css
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukRadios: GovukRadios,
-    govukButton: GovukButton,
-    caption: Caption,
-    subHeading: SubHeading,
-    pageHeading: PageHeading,
-    bulletList: BulletList,
-    paragraph: Paragraph,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios: GovukRadios,
+        govukButton: GovukButton,
+        caption: Caption,
+        subHeading: SubHeading,
+        pageHeading: PageHeading,
+        bulletList: BulletList,
+        paragraph: Paragraph,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("declareAdjustmentQuestion.title"))) {
 
-        @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form))
-        }
-        @caption(
-            id = "declare-adjustment-question-section",
-            text = messages("section.adjustment"),
-        )
+    @if(form.errors.nonEmpty) {
+        @govukErrorSummary(ErrorSummaryViewModel(form))
+    }
+    @caption(
+        id = "declare-adjustment-question-section",
+        text = messages("section.adjustment"),
+    )
 
-        @pageHeading(messages("declareAdjustmentQuestion.heading"))
+    @pageHeading(messages("declareAdjustmentQuestion.heading"))
 
-        @paragraph(messages("declareAdjustmentQuestion.p1"))
+    @paragraph(messages("declareAdjustmentQuestion.p1"))
 
-        @bulletList(Seq(
+    @bulletList(Seq(
         messages("declareAdjustmentQuestion.para1.list1"),
         messages("declareAdjustmentQuestion.para1.list2"),
-        ))
+    ))
 
-        @paragraph(messages("declareAdjustmentQuestion.p2"))
-        @paragraph(messages("declareAdjustmentQuestion.p3"))
+    @paragraph(messages("declareAdjustmentQuestion.p2"))
+    @paragraph(messages("declareAdjustmentQuestion.p3"))
 
-        @bulletList(Seq(
+    @bulletList(Seq(
         messages("declareAdjustmentQuestion.para1.list3"),
         messages("declareAdjustmentQuestion.para1.list4"),
         messages("declareAdjustmentQuestion.para1.list5"),
-        ))
+    ))
 
-        @formHelper(action = controllers.adjustment.routes.DeclareAdjustmentQuestionController.onSubmit(mode), Symbol("autoComplete") -> "off") {
+    @formHelper(action = controllers.adjustment.routes.DeclareAdjustmentQuestionController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
-        @formGroupWithError(form.errors.nonEmpty){
-                @subHeading(messages("declareAdjustmentQuestion.question.h2"), classes = Css.headingMCssClass)
+        @formGroupWithError(form.errors.nonEmpty) {
+            @subHeading(messages("declareAdjustmentQuestion.question.h2"), classes = Css.headingMCssClass)
 
-                @govukRadios(
-                    RadiosViewModel.yesNo(
-                        field = form("declare-adjustment-question-value"),
-                        legend = LegendViewModel(messages("declareAdjustmentQuestion.heading")).asVisuallyHidden()
-                    )
+            @govukRadios(
+                RadiosViewModel.yesNo(
+                    field = form("declare-adjustment-question-value"),
+                    legend = LegendViewModel(messages("declareAdjustmentQuestion.heading")).asVisuallyHidden()
                 )
+            )
         }
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
     }
 }

--- a/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
+++ b/app/views/adjustment/DeclareAdjustmentQuestionView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, SubHeading, PageHeading, Paragraph, BulletList, FormGroupWithError}
 @import config.Constants.Css
 

--- a/app/views/adjustment/DeleteAdjustmentView.scala.html
+++ b/app/views/adjustment/DeleteAdjustmentView.scala.html
@@ -1,30 +1,29 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{FormGroupWithError, PageHeading, Paragraph}
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukRadios: GovukRadios,
-    govukButton: GovukButton,
-    paragraph: Paragraph,
-    pageHeading: PageHeading,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios: GovukRadios,
+        govukButton: GovukButton,
+        paragraph: Paragraph,
+        pageHeading: PageHeading,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], index: Int)(implicit request: Request[_], messages: Messages)
@@ -33,23 +32,23 @@
 
     @formHelper(action = controllers.adjustment.routes.DeleteAdjustmentController.onSubmit(index), Symbol("autoComplete") -> "off") {
 
-    @if(form.errors.nonEmpty) {
-        @govukErrorSummary(ErrorSummaryViewModel(form))
-    }
-    @formGroupWithError(form.errors.nonEmpty){
-        @pageHeading(messages("deleteAdjustment.heading"))
+        @if(form.errors.nonEmpty) {
+            @govukErrorSummary(ErrorSummaryViewModel(form))
+        }
+        @formGroupWithError(form.errors.nonEmpty) {
+            @pageHeading(messages("deleteAdjustment.heading"))
 
-        @paragraph(messages("deleteAdjustment.paragraph"))
+            @paragraph(messages("deleteAdjustment.paragraph"))
 
-        @govukRadios(
-            RadiosViewModel.yesNo(
-            field = form("delete-adjustment-yes-no-value"),
-            legend = LegendViewModel(messages("deleteAdjustment.heading")).asVisuallyHidden()
+            @govukRadios(
+                RadiosViewModel.yesNo(
+                    field = form("delete-adjustment-yes-no-value"),
+                    legend = LegendViewModel(messages("deleteAdjustment.heading")).asVisuallyHidden()
+                )
             )
+        }
+        @govukButton(
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
-    }
-    @govukButton(
-        ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
-    )
     }
 }

--- a/app/views/adjustment/DeleteAdjustmentView.scala.html
+++ b/app/views/adjustment/DeleteAdjustmentView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{FormGroupWithError, PageHeading, Paragraph}
 
 @this(

--- a/app/views/adjustment/DeleteAdjustmentView.scala.html
+++ b/app/views/adjustment/DeleteAdjustmentView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{FormGroupWithError, PageHeading, Paragraph}
 
 @this(

--- a/app/views/adjustment/OverDeclarationReasonView.scala.html
+++ b/app/views/adjustment/OverDeclarationReasonView.scala.html
@@ -1,37 +1,36 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading}
 @import config.Constants
 @import forms.adjustment.OverDeclarationReasonFormProvider
 @import viewmodels.InputWidth._
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    hmrcCharacterCount: HmrcCharacterCount
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        hmrcCharacterCount: HmrcCharacterCount
 )
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
 
-    @layout(pageTitle = title(form, messages("overDeclarationReason.title"))) {
+@layout(pageTitle = title(form, messages("overDeclarationReason.title"))) {
 
     @formHelper(action = controllers.adjustment.routes.OverDeclarationReasonController.onSubmit(mode)) {
 
@@ -49,12 +48,12 @@
                 field = form("over-declaration-reason-input"),
                 label = LabelViewModel(messages("overDeclarationReason.heading")).asPageHeading()
             )
-            .withWidth(TwoThirds)
-            .withMaxLength(Constants.overUnderDeclarationReasonLength)
+                    .withWidth(TwoThirds)
+                    .withMaxLength(Constants.overUnderDeclarationReasonLength)
         )
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.continue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.continue"))
         )
     }
 }

--- a/app/views/adjustment/OverDeclarationReasonView.scala.html
+++ b/app/views/adjustment/OverDeclarationReasonView.scala.html
@@ -1,21 +1,21 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
-@import components.{Caption, PageHeading}
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import components.Caption
 @import config.Constants
-@import forms.adjustment.OverDeclarationReasonFormProvider
 @import viewmodels.InputWidth._
 
 @this(

--- a/app/views/adjustment/OverDeclarationReasonView.scala.html
+++ b/app/views/adjustment/OverDeclarationReasonView.scala.html
@@ -1,19 +1,18 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.Caption
 @import config.Constants
 @import viewmodels.InputWidth._

--- a/app/views/adjustment/OverDeclarationReasonView.scala.html
+++ b/app/views/adjustment/OverDeclarationReasonView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.Caption
 @import config.Constants
 @import viewmodels.InputWidth._

--- a/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
+++ b/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
@@ -1,34 +1,33 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, FormGroupWithError}
 @import viewmodels.checkAnswers.adjustment.SpoiltAlcoholicProductTypeHelper
 @import viewmodels.adjustment.SpoiltAlcoholicProductTypeViewModel
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukRadios: GovukRadios,
-    govukButton: GovukButton,
-    caption: Caption,
-    paragraph: Paragraph,
-    pageHeading: PageHeading,
-    helper: SpoiltAlcoholicProductTypeHelper,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios: GovukRadios,
+        govukButton: GovukButton,
+        caption: Caption,
+        paragraph: Paragraph,
+        pageHeading: PageHeading,
+        helper: SpoiltAlcoholicProductTypeHelper,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], mode: Mode, viewModel: SpoiltAlcoholicProductTypeViewModel)(implicit request: Request[_], messages: Messages)
@@ -38,7 +37,7 @@
     @formHelper(action = controllers.adjustment.routes.SpoiltAlcoholicProductTypeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("alcoholic-product-type-value" -> viewModel.getTopRadioId)))
+            @govukErrorSummary(ErrorSummaryViewModel(form, errorLinkOverrides = Map("alcoholic-product-type-value" -> viewModel.getTopRadioId)))
         }
 
         @caption(
@@ -46,22 +45,22 @@
             text = messages("section.adjustment")
         )
 
-        @formGroupWithError(form.errors.nonEmpty){
-                @pageHeading(messages("alcoholicProductType.heading"))
+        @formGroupWithError(form.errors.nonEmpty) {
+            @pageHeading(messages("alcoholicProductType.heading"))
 
-                @paragraph(messages("alcoholicProductType.paragraph"))
+            @paragraph(messages("alcoholicProductType.paragraph"))
 
-                @govukRadios(
-                    RadiosViewModel(
-                        field  = form("alcoholic-product-type-value"),
-                        legend = LegendViewModel(messages("alcoholicProductType.heading")).asVisuallyHidden(),
-                        items  = viewModel.radioOptions
-                    )
+            @govukRadios(
+                RadiosViewModel(
+                    field = form("alcoholic-product-type-value"),
+                    legend = LegendViewModel(messages("alcoholicProductType.heading")).asVisuallyHidden(),
+                    items = viewModel.radioOptions
                 )
+            )
         }
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
     }
 }

--- a/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
+++ b/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, Paragraph, FormGroupWithError}
 @import viewmodels.checkAnswers.adjustment.SpoiltAlcoholicProductTypeHelper
 @import viewmodels.adjustment.SpoiltAlcoholicProductTypeViewModel

--- a/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
+++ b/app/views/adjustment/SpoiltAlcoholicProductTypeView.scala.html
@@ -15,8 +15,8 @@
  *@
 
 @import components.{Caption, PageHeading, Paragraph, FormGroupWithError}
-@import models.AlcoholRegimes
 @import viewmodels.checkAnswers.adjustment.SpoiltAlcoholicProductTypeHelper
+@import viewmodels.adjustment.SpoiltAlcoholicProductTypeViewModel
 
 @this(
     layout: templates.Layout,
@@ -31,14 +31,14 @@
     formGroupWithError: FormGroupWithError
 )
 
-@(form: Form[_], mode: Mode, regimes: AlcoholRegimes)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, viewModel: SpoiltAlcoholicProductTypeViewModel)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = title(form, messages("alcoholicProductType.title"))) {
 
     @formHelper(action = controllers.adjustment.routes.SpoiltAlcoholicProductTypeController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
         @if(form.errors.nonEmpty) {
-            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("alcoholic-product-type-value" -> helper.radioOptions(regimes).headOption.flatMap(_.id).getOrElse(""))))
+            @govukErrorSummary(ErrorSummaryViewModel(form,  errorLinkOverrides = Map("alcoholic-product-type-value" -> viewModel.getTopRadioId)))
         }
 
         @caption(
@@ -55,7 +55,7 @@
                     RadiosViewModel(
                         field  = form("alcoholic-product-type-value"),
                         legend = LegendViewModel(messages("alcoholicProductType.heading")).asVisuallyHidden(),
-                        items  = helper.radioOptions(regimes)
+                        items  = viewModel.radioOptions
                     )
                 )
         }

--- a/app/views/adjustment/SpoiltVolumeWithDutyView.scala.html
+++ b/app/views/adjustment/SpoiltVolumeWithDutyView.scala.html
@@ -1,34 +1,33 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import viewmodels.InputWidth._
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    pageHeading: PageHeading,
-    paragraph: Paragraph,
-    subHeading: SubHeading,
-    govukFieldset: GovukFieldset
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        pageHeading: PageHeading,
+        paragraph: Paragraph,
+        subHeading: SubHeading,
+        govukFieldset: GovukFieldset
 )
 
 @(form: Form[_], mode: Mode, regime: AlcoholRegime)(implicit request: Request[_], messages: Messages)
@@ -47,58 +46,58 @@
         )
 
         @govukFieldset(Fieldset(
-          legend = Some(Legend(
-            content = Text(messages(s"spoiltVolumeWithDuty.heading.${regime.regimeMessageKey}")),
-            classes = Css.fieldsetLegendXLCssClass,
-            isPageHeading = true
-          )),
-          html = HtmlFormat.fill(List(
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key="totalLitresVolume",
-                label = LabelViewModel(messages(s"spoiltVolumeWithDuty.totalLitresVolume.heading.${regime.regimeMessageKey}")),
-                errorMessageField = form(s"volumes_totalLitresVolume"),
-                value = form(s"volumes.totalLitresVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
-            ),
+            legend = Some(Legend(
+                content = Text(messages(s"spoiltVolumeWithDuty.heading.${regime.regimeMessageKey}")),
+                classes = Css.fieldsetLegendXLCssClass,
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(List(
+                govukInput(
+                    InputViewModel(
+                        field = form("volumes"),
+                        key = "totalLitresVolume",
+                        label = LabelViewModel(messages(s"spoiltVolumeWithDuty.totalLitresVolume.heading.${regime.regimeMessageKey}")),
+                        errorMessageField = form(s"volumes_totalLitresVolume"),
+                        value = form(s"volumes.totalLitresVolume").value
+                    )
+                            .asNumeric()
+                            .withWidth(Fixed10)
+                            .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                            .withHint(Hint(content = messages("adjustmentVolume.totalLitresVolume.hint")))
+                ),
 
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key="pureAlcoholVolume",
-                label = LabelViewModel(messages("spoiltVolumeWithDuty.pureAlcoholVolume.heading")),
-                errorMessageField = form(s"volumes_pureAlcoholVolume"),
-                value = form(s"volumes.pureAlcoholVolume").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
-              .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
-            ),
+                govukInput(
+                    InputViewModel(
+                        field = form("volumes"),
+                        key = "pureAlcoholVolume",
+                        label = LabelViewModel(messages("spoiltVolumeWithDuty.pureAlcoholVolume.heading")),
+                        errorMessageField = form(s"volumes_pureAlcoholVolume"),
+                        value = form(s"volumes.pureAlcoholVolume").value
+                    )
+                            .asNumeric()
+                            .withWidth(Fixed10)
+                            .withSuffix(PrefixOrSuffix(content = messages("site.unit.litres")))
+                            .withHint(Hint(content = messages("adjustmentVolume.pureAlcoholVolume.hint")))
+                ),
 
-            govukInput(
-              InputViewModel(
-                field = form("volumes"),
-                key="duty",
-                label = LabelViewModel(messages("spoiltVolumeWithDuty.spoiltDuty.heading")),
-                errorMessageField = form(s"volumes_duty"),
-                value = form(s"volumes.duty").value
-              )
-              .asNumeric()
-              .withWidth(Fixed10)
-              .withPoundPrefix
-              .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
-            )
-          ))
+                govukInput(
+                    InputViewModel(
+                        field = form("volumes"),
+                        key = "duty",
+                        label = LabelViewModel(messages("spoiltVolumeWithDuty.spoiltDuty.heading")),
+                        errorMessageField = form(s"volumes_duty"),
+                        value = form(s"volumes.duty").value
+                    )
+                            .asNumeric()
+                            .withWidth(Fixed10)
+                            .withPoundPrefix
+                            .withHint(HintViewModel(messages("adjustmentSmallProducerReliefDutyRate.hint")))
+                )
+            ))
         ))
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.saveAndContinue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )
     }
 }

--- a/app/views/adjustment/SpoiltVolumeWithDutyView.scala.html
+++ b/app/views/adjustment/SpoiltVolumeWithDutyView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading, Paragraph, SubHeading}
 @import config.Constants.Css
 @import viewmodels.InputWidth._

--- a/app/views/adjustment/UnderDeclarationReasonView.scala.html
+++ b/app/views/adjustment/UnderDeclarationReasonView.scala.html
@@ -1,32 +1,31 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Caption, PageHeading}
 @import config.Constants
 @import forms.adjustment.UnderDeclarationReasonFormProvider
 @import viewmodels.InputWidth._
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukInput: GovukInput,
-    govukButton: GovukButton,
-    caption: Caption,
-    hmrcCharacterCount: HmrcCharacterCount
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukInput: GovukInput,
+        govukButton: GovukButton,
+        caption: Caption,
+        hmrcCharacterCount: HmrcCharacterCount
 )
 
 @(form: Form[_], mode: Mode)(implicit request: Request[_], messages: Messages)
@@ -49,12 +48,12 @@
                 field = form("under-declaration-reason-input"),
                 label = LabelViewModel(messages("underDeclarationReason.heading")).asPageHeading()
             )
-            .withWidth(TwoThirds)
-            .withMaxLength(Constants.overUnderDeclarationReasonLength)
+                    .withWidth(TwoThirds)
+                    .withMaxLength(Constants.overUnderDeclarationReasonLength)
         )
 
         @govukButton(
-            ButtonViewModel("saveAndContinueButton",messages("site.continue"))
+            ButtonViewModel("saveAndContinueButton", messages("site.continue"))
         )
     }
 }

--- a/app/views/adjustment/UnderDeclarationReasonView.scala.html
+++ b/app/views/adjustment/UnderDeclarationReasonView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Caption, PageHeading}
 @import config.Constants
 @import forms.adjustment.UnderDeclarationReasonFormProvider

--- a/app/views/adjustment/WhenDidYouPayDutyView.scala.html
+++ b/app/views/adjustment/WhenDidYouPayDutyView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Link, PageHeading, Paragraph, Caption, FormGroupWithError}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType

--- a/app/views/adjustment/WhenDidYouPayDutyView.scala.html
+++ b/app/views/adjustment/WhenDidYouPayDutyView.scala.html
@@ -16,8 +16,8 @@
 
 @import components.{Link, PageHeading, Paragraph, Caption, FormGroupWithError}
 @import config.Constants.Css
-@import models.adjustment.AdjustmentType
 @import models.adjustment.AdjustmentType.{Underdeclaration, Spoilt}
+@import viewmodels.adjustment.WhenDidYouPayDutyViewModel
 
 @this(
         layout: templates.Layout,
@@ -32,19 +32,9 @@
         formGroupWithError: FormGroupWithError
 )
 
-@(form: Form[_], mode: Mode, adjustmentType: AdjustmentType, exciseEnquiriesUrl: String)(implicit request: Request[_], messages: Messages)
+@(form: Form[_], mode: Mode, viewModel: WhenDidYouPayDutyViewModel)(implicit request: Request[_], messages: Messages)
 
-@heading = @{
-    if(adjustmentType == Underdeclaration) {
-        messages("whenDidYouPayDuty.under-declaration.title")
-    } else if(adjustmentType == Spoilt) {
-        throw new IllegalArgumentException("Not expecting WhenDidYouPayDuty to be asked for Spoilt")
-    } else {
-        messages("whenDidYouPayDuty.default.title")
-    }
-}
-
-@layout(pageTitle = title(form, heading)) {
+@layout(pageTitle = title(form, viewModel.getHeading)) {
 
     @formHelper(action = controllers.adjustment.routes.WhenDidYouPayDutyController.onSubmit(mode), Symbol("autoComplete") -> "off") {
 
@@ -54,23 +44,17 @@
 
         @caption(
             id = "when-did-you-pay-duty-section",
-            messages(s"section.adjustment.$adjustmentType"),
+            messages(s"section.adjustment.${viewModel.adjustmentType}"),
         )
 
         @formGroupWithError(form.errors.nonEmpty) {
-            @pageHeading(
-                if(adjustmentType == Underdeclaration) {
-                    messages("whenDidYouPayDuty.under-declaration.heading")
-                } else {
-                    messages("whenDidYouPayDuty.default.heading")
-                }
-            )
+            @pageHeading(viewModel.getHeading)
 
             <p class="@Css.bodyCssClass">
                 @link(
                     id = "excise-enquiries-link",
                     text = messages("whenDidYouPayDuty.exciseEnquiries.link"),
-                    href = exciseEnquiriesUrl,
+                    href = viewModel.exciseEnquiriesUrl,
                     newTab = true
                 )
                 @messages("whenDidYouPayDuty.paragraph")
@@ -80,7 +64,7 @@
                 YearMonthDateViewModel(
                     form = form,
                     id = "when-did-you-pay-duty-input",
-                    legend = LegendViewModel(messages(heading)).asVisuallyHidden(),
+                    legend = LegendViewModel(viewModel.getHeading).asVisuallyHidden(),
                 ).withHint(HintViewModel(messages("whenDidYouPayDuty.hint")))
             )
         }

--- a/app/views/adjustment/WhenDidYouPayDutyView.scala.html
+++ b/app/views/adjustment/WhenDidYouPayDutyView.scala.html
@@ -1,43 +1,42 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Link, PageHeading, Paragraph, Caption, FormGroupWithError}
 @import config.Constants.Css
 @import models.adjustment.AdjustmentType
 @import models.adjustment.AdjustmentType.{Underdeclaration, Spoilt}
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukDateInput: GovukDateInput,
-    govukButton: GovukButton,
-    paragraph: Paragraph,
-    caption: Caption,
-    pageHeading: PageHeading,
-    link: Link,
-    formGroupWithError: FormGroupWithError
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukDateInput: GovukDateInput,
+        govukButton: GovukButton,
+        paragraph: Paragraph,
+        caption: Caption,
+        pageHeading: PageHeading,
+        link: Link,
+        formGroupWithError: FormGroupWithError
 )
 
 @(form: Form[_], mode: Mode, adjustmentType: AdjustmentType, exciseEnquiriesUrl: String)(implicit request: Request[_], messages: Messages)
 
 @heading = @{
-    if (adjustmentType == Underdeclaration) {
+    if(adjustmentType == Underdeclaration) {
         messages("whenDidYouPayDuty.under-declaration.title")
-    } else if (adjustmentType == Spoilt) {
+    } else if(adjustmentType == Spoilt) {
         throw new IllegalArgumentException("Not expecting WhenDidYouPayDuty to be asked for Spoilt")
     } else {
         messages("whenDidYouPayDuty.default.title")
@@ -57,33 +56,33 @@
             messages(s"section.adjustment.$adjustmentType"),
         )
 
-        @formGroupWithError(form.errors.nonEmpty){
-                @pageHeading(
-                            if (adjustmentType == Underdeclaration){
-                                messages("whenDidYouPayDuty.under-declaration.heading")
-                            } else {
-                                messages("whenDidYouPayDuty.default.heading")
-                            }
-                            )
-
-        <p class="@Css.bodyCssClass">
-            @link(
-                id = "excise-enquiries-link",
-                text = messages("whenDidYouPayDuty.exciseEnquiries.link"),
-                href = exciseEnquiriesUrl,
-                newTab = true
+        @formGroupWithError(form.errors.nonEmpty) {
+            @pageHeading(
+                if(adjustmentType == Underdeclaration) {
+                    messages("whenDidYouPayDuty.under-declaration.heading")
+                } else {
+                    messages("whenDidYouPayDuty.default.heading")
+                }
             )
-            @messages("whenDidYouPayDuty.paragraph")
-        </p>
 
-        @govukDateInput(
-            YearMonthDateViewModel(
-                form = form,
-                id = "when-did-you-pay-duty-input",
-                legend = LegendViewModel(messages(heading)).asVisuallyHidden(),
-            ).withHint(HintViewModel(messages("whenDidYouPayDuty.hint")))
-        )
-    }
+            <p class="@Css.bodyCssClass">
+                @link(
+                    id = "excise-enquiries-link",
+                    text = messages("whenDidYouPayDuty.exciseEnquiries.link"),
+                    href = exciseEnquiriesUrl,
+                    newTab = true
+                )
+                @messages("whenDidYouPayDuty.paragraph")
+            </p>
+
+            @govukDateInput(
+                YearMonthDateViewModel(
+                    form = form,
+                    id = "when-did-you-pay-duty-input",
+                    legend = LegendViewModel(messages(heading)).asVisuallyHidden(),
+                ).withHint(HintViewModel(messages("whenDidYouPayDuty.hint")))
+            )
+        }
         @govukButton(
             ButtonViewModel("saveAndContinueButton", messages("site.saveAndContinue"))
         )

--- a/app/views/auth/DoYouHaveAnAppaIdView.scala.html
+++ b/app/views/auth/DoYouHaveAnAppaIdView.scala.html
@@ -1,25 +1,24 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukRadios: GovukRadios,
-    govukButton: GovukButton,
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukRadios: GovukRadios,
+        govukButton: GovukButton,
 )
 
 @(form: Form[_], wasReferredFromBTA: Boolean, signedIn: Boolean)(implicit request: Request[_], messages: Messages)
@@ -40,7 +39,7 @@
         )
 
         @govukButton(
-            ButtonViewModel("continueButton",messages("site.continue"))
+            ButtonViewModel("continueButton", messages("site.continue"))
         )
     }
 }

--- a/app/views/auth/DoYouHaveAnAppaIdView.scala.html
+++ b/app/views/auth/DoYouHaveAnAppaIdView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
         layout: templates.Layout,
         formHelper: FormWithCSRF,

--- a/app/views/auth/NoAppaIdView.scala.html
+++ b/app/views/auth/NoAppaIdView.scala.html
@@ -1,18 +1,19 @@
 @*
-* Copyright 2024 HM Revenue & Customs
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*@
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @import components.{Link, PageHeading, Paragraph}
 @import config.Constants.Css
 @import config.FrontendAppConfig

--- a/app/views/auth/NoAppaIdView.scala.html
+++ b/app/views/auth/NoAppaIdView.scala.html
@@ -1,55 +1,56 @@
 @*
- * Copyright 2024 HM Revenue & Customs
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *@
-
+* Copyright 2024 HM Revenue & Customs
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*@
 @import components.{Link, PageHeading, Paragraph}
 @import config.Constants.Css
 @import config.FrontendAppConfig
 
 @this(
-    layout: templates.Layout,
-    formHelper: FormWithCSRF,
-    govukErrorSummary: GovukErrorSummary,
-    govukButton: GovukButton,
-    link: Link,
-    pageHeading: PageHeading,
-    paragraph: Paragraph
+        layout: templates.Layout,
+        formHelper: FormWithCSRF,
+        govukErrorSummary: GovukErrorSummary,
+        govukButton: GovukButton,
+        link: Link,
+        pageHeading: PageHeading,
+        paragraph: Paragraph
 )
 
 @(appConfig: FrontendAppConfig, wasReferredFromBTA: Boolean, signedIn: Boolean)(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("noAppaId.title")), timeout = signedIn, showSignOut = signedIn) {
+
     @formHelper(action = controllers.auth.routes.NoAppaIdController.onSubmit(wasReferredFromBTA), Symbol("autoComplete") -> "off") {
+
         @pageHeading(messages("noAppaId.heading"))
 
         @paragraph(messages("noAppaId.p"))
 
         <p class="@Css.bodyCssClass">
             @link(
-            id = "register-for-alcohol-duty",
-            text = messages("noAppaId.link.text"),
-            href = appConfig.appaIdRegisterUrl,
-            newTab = true
+                id = "register-for-alcohol-duty",
+                text = messages("noAppaId.link.text"),
+                href = appConfig.appaIdRegisterUrl,
+                newTab = true
             )
             @messages("noAppaId.p2")
         </p>
 
         @if(wasReferredFromBTA) {
             @govukButton(
-                ButtonViewModel("return-to-business-account",messages("site.returnToBusinessAccount"))
-                .withCssClass(Css.secondaryButtonCssClass)
+                ButtonViewModel("return-to-business-account", messages("site.returnToBusinessAccount"))
+                        .withCssClass(Css.secondaryButtonCssClass)
             )
         }
     }

--- a/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
+++ b/app/views/checkAndSubmit/DutyDueForThisReturnView.scala.html
@@ -28,78 +28,72 @@
         paragraph: Paragraph,
         subHeading: SubHeading,
         bulletList: BulletList,
-        govukSummaryList : GovukSummaryList
+        govukSummaryList: GovukSummaryList
 )
 
 @(dutyDueViewModel: DutyDueForThisReturnViewModel)(implicit request: Request[_], messages: Messages)
 
-@titleMessage = @{
-  if (dutyDueViewModel.totalDue == 0) {
-    messages("dutyDueForThisReturn.nil.title")
-  } else {
-    messages("dutyDueForThisReturn.title", messages("site.currency.2DP", dutyDueViewModel.totalDue))
-  }
-}
-
 @heading = @{
-    if (dutyDueViewModel.totalDue == 0) {
+    if(dutyDueViewModel.isTotalDueZero) {
         pageHeading(messages("dutyDueForThisReturn.nil.heading"))
     } else {
         pageHeadingWithMonetaryValue(messages("dutyDueForThisReturn.heading"), dutyDueViewModel.totalDue)
     }
 }
 
-@layout(pageTitle = titleNoForm(titleMessage)) {
-  @formHelper(action = controllers.checkAndSubmit.routes.DutyDueForThisReturnController.onSubmit(), Symbol("autoComplete") -> "off") {
-      @caption(
-      id = "dutyDueForThisReturn-section",
-      text = messages("section.checkAndSubmit"),
-    )
+@layout(pageTitle = titleNoForm(dutyDueViewModel.getTitle)) {
 
-      @heading
+    @formHelper(action = controllers.checkAndSubmit.routes.DutyDueForThisReturnController.onSubmit(), Symbol("autoComplete") -> "off") {
 
-    @if(dutyDueViewModel.totalDue == 0) {
-      @paragraph(messages("dutyDueForThisReturn.nil.p1"))
+        @caption(
+            id = "dutyDueForThisReturn-section",
+            text = messages("section.checkAndSubmit"),
+        )
 
-      @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
+        @heading
 
-      @bulletList(Seq(messages("dutyDueForThisReturn.bulletList.3")))
+        @if(dutyDueViewModel.isTotalDueZero) {
+            @paragraph(messages("dutyDueForThisReturn.nil.p1"))
+
+            @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
+
+            @bulletList(Seq(messages("dutyDueForThisReturn.bulletList.3")))
+        }
+
+        @if(dutyDueViewModel.isTotalDueAboveZero) {
+            @paragraph(messages("dutyDueForThisReturn.positive.p1"))
+
+            @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
+
+            @bulletList(Seq(
+                messages("dutyDueForThisReturn.bulletList.1")
+            ))
+        }
+
+        @if(dutyDueViewModel.isTotalDueBelowZero) {
+            @paragraph(messages("dutyDueForThisReturn.negative.p1"))
+
+            @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
+
+            @bulletList(Seq(
+                messages("dutyDueForThisReturn.bulletList.1")
+            ))
+        }
+
+        @paragraph(messages("dutyDueForThisReturn.p2"))
+
+        @subHeading(messages("dutyDueForThisReturn.h3"), classes = Css.headingMCssClass)
+        @govukSummaryList(dutyDueViewModel.dutiesBreakdownSummaryList)
+
+        @subHeading(messages("dutyDueForThisReturn.youveAlsoAnswered"), classes = Css.headingMCssClass)
+        @paragraph(messages("dutyDueForThisReturn.youveAlsoAnswered.p"))
+        @govukSummaryList(dutyDueViewModel.youveAlsoDeclaredSummaryList)
+
+        @subHeading(messages("dutyDueForThisReturn.h4"), classes = Css.headingMCssClass)
+        @paragraph(messages("dutyDueForThisReturn.p3"))
+
+        @govukButton(
+            ButtonViewModel("continueButton", messages("site.agreeAndSubmit"))
+        )
     }
-
-    @if(dutyDueViewModel.totalDue > 0) {
-      @paragraph(messages("dutyDueForThisReturn.positive.p1"))
-
-      @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
-
-      @bulletList(Seq(
-        messages("dutyDueForThisReturn.bulletList.1")
-      ))
-    }
-
-    @if(dutyDueViewModel.totalDue < 0) {
-      @paragraph(messages("dutyDueForThisReturn.negative.p1"))
-
-      @subHeading(messages("dutyDueForThisReturn.h2"), classes = Css.headingMCssClass)
-
-      @bulletList(Seq(
-        messages("dutyDueForThisReturn.bulletList.1")
-      ))
-    }
-
-    @paragraph(messages("dutyDueForThisReturn.p2"))
-
-    @subHeading(messages("dutyDueForThisReturn.h3"), classes = Css.headingMCssClass)
-    @govukSummaryList(dutyDueViewModel.dutiesBreakdownSummaryList)
-
-    @subHeading(messages("dutyDueForThisReturn.youveAlsoAnswered"), classes = Css.headingMCssClass)
-    @paragraph(messages("dutyDueForThisReturn.youveAlsoAnswered.p"))
-    @govukSummaryList(dutyDueViewModel.youveAlsoDeclaredSummaryList)
-
-    @subHeading(messages("dutyDueForThisReturn.h4"), classes = Css.headingMCssClass)
-    @paragraph(messages("dutyDueForThisReturn.p3"))
-
-    @govukButton(
-      ButtonViewModel("continueButton", messages("site.agreeAndSubmit"))
-    )
-  }
 }

--- a/test/controllers/adjustment/AdjustmentListControllerSpec.scala
+++ b/test/controllers/adjustment/AdjustmentListControllerSpec.scala
@@ -34,7 +34,7 @@ import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HttpResponse
-import viewmodels.TableViewModel
+import viewmodels.{PaginationViewModel, TableViewModel}
 import viewmodels.checkAnswers.adjustment.AdjustmentListSummaryHelper
 import views.html.adjustment.AdjustmentListView
 
@@ -43,7 +43,7 @@ import scala.concurrent.Future
 
 class AdjustmentListControllerSpec extends SpecBase {
 
-  def onwardRoute = Call("GET", "/foo")
+  def onwardRoute: Call = Call("GET", "/foo")
 
   val formProvider                              = new AdjustmentListFormProvider()
   val form: Form[Boolean]                       = formProvider()
@@ -132,8 +132,14 @@ class AdjustmentListControllerSpec extends SpecBase {
 
         val totalPages = Math.ceil(userAnswers.get(AdjustmentEntryListPage).size.toDouble / rowsPerPage).toInt
 
+        val paginationViewModel: PaginationViewModel = PaginationViewModel(
+          pageNumber,
+          totalPages,
+          controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
+        )
+
         status(result)          mustEqual OK
-        contentAsString(result) mustEqual view(form, adjustmentTable, totalPages, pageNumber)(
+        contentAsString(result) mustEqual view(form, adjustmentTable, paginationViewModel)(
           request,
           getMessages(app)
         ).toString
@@ -168,8 +174,14 @@ class AdjustmentListControllerSpec extends SpecBase {
 
         val totalPages = Math.ceil(userAnswers.get(AdjustmentEntryListPage).size.toDouble / rowsPerPage).toInt
 
+        val paginationViewModel: PaginationViewModel = PaginationViewModel(
+          pageNumber,
+          totalPages,
+          controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
+        )
+
         status(result)          mustEqual OK
-        contentAsString(result) mustEqual view(form.fill(true), adjustmentTable, totalPages, pageNumber)(
+        contentAsString(result) mustEqual view(form.fill(true), adjustmentTable, paginationViewModel)(
           request,
           getMessages(app)
         ).toString
@@ -259,8 +271,14 @@ class AdjustmentListControllerSpec extends SpecBase {
 
         val totalPages = Math.ceil(userAnswers.get(AdjustmentEntryListPage).size.toDouble / rowsPerPage).toInt
 
+        val paginationViewModel: PaginationViewModel = PaginationViewModel(
+          pageNumber,
+          totalPages,
+          controllers.adjustment.routes.AdjustmentListController.onPageLoad(_).url
+        )
+
         status(result)          mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, adjustmentTable, totalPages, pageNumber)(
+        contentAsString(result) mustEqual view(boundForm, adjustmentTable, paginationViewModel)(
           request,
           getMessages(app)
         ).toString

--- a/test/controllers/adjustment/SpoiltAlcoholicProductTypeControllerSpec.scala
+++ b/test/controllers/adjustment/SpoiltAlcoholicProductTypeControllerSpec.scala
@@ -17,18 +17,19 @@
 package controllers.adjustment
 
 import base.SpecBase
+import connectors.UserAnswersConnector
 import forms.adjustment.AlcoholicProductTypeFormProvider
+import models.AlcoholRegime.{Beer, Cider}
+import models.adjustment.{AdjustmentEntry, AdjustmentType}
 import models.{NormalMode, ReturnPeriod}
 import navigation.AdjustmentNavigator
 import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchersSugar.eqTo
 import pages.adjustment.CurrentAdjustmentEntryPage
+import play.api.i18n.Messages
 import play.api.inject.bind
 import play.api.mvc.Call
 import play.api.test.Helpers._
-import connectors.UserAnswersConnector
-import models.AlcoholRegime.{Beer, Cider}
-import models.adjustment.{AdjustmentEntry, AdjustmentType}
-import org.mockito.ArgumentMatchersSugar.eqTo
 import uk.gov.hmrc.http.HttpResponse
 import viewmodels.checkAnswers.adjustment.SpoiltAlcoholicProductTypeHelper
 import views.html.adjustment.SpoiltAlcoholicProductTypeView
@@ -52,8 +53,11 @@ class SpoiltAlcoholicProductTypeControllerSpec extends SpecBase {
 
         val view = application.injector.instanceOf[SpoiltAlcoholicProductTypeView]
 
+        val helper        = application.injector.instanceOf[SpoiltAlcoholicProductTypeHelper]
+        val testViewModel = helper.getViewModel(userAnswers.regimes)(getMessages(application))
+
         status(result)          mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, userAnswers.regimes)(
+        contentAsString(result) mustEqual view(form, NormalMode, testViewModel)(
           request,
           getMessages(application)
         ).toString
@@ -78,8 +82,11 @@ class SpoiltAlcoholicProductTypeControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
+        val helper        = application.injector.instanceOf[SpoiltAlcoholicProductTypeHelper]
+        val testViewModel = helper.getViewModel(userAnswers.regimes)(getMessages(application))
+
         status(result)          mustEqual OK
-        contentAsString(result) mustEqual view(form.fill(alcoholType), NormalMode, userAnswers.regimes)(
+        contentAsString(result) mustEqual view(form.fill(alcoholType), NormalMode, testViewModel)(
           request,
           getMessages(application)
         ).toString
@@ -300,8 +307,11 @@ class SpoiltAlcoholicProductTypeControllerSpec extends SpecBase {
 
         val result = route(application, request).value
 
+        val helper        = application.injector.instanceOf[SpoiltAlcoholicProductTypeHelper]
+        val testViewModel = helper.getViewModel(emptyUserAnswers.regimes)(getMessages(application))
+
         status(result)          mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, emptyUserAnswers.regimes)(
+        contentAsString(result) mustEqual view(boundForm, NormalMode, testViewModel)(
           request,
           getMessages(application)
         ).toString

--- a/test/controllers/adjustment/SpoiltAlcoholicProductTypeHelperSpec.scala
+++ b/test/controllers/adjustment/SpoiltAlcoholicProductTypeHelperSpec.scala
@@ -24,6 +24,7 @@ import models.{ABVRange, AlcoholByVolume, AlcoholRegime, AlcoholRegimes, Alcohol
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.Text
 import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+import viewmodels.adjustment.SpoiltAlcoholicProductTypeViewModel
 import viewmodels.checkAnswers.adjustment.SpoiltAlcoholicProductTypeHelper
 
 class SpoiltAlcoholicProductTypeHelperSpec extends SpecBase {
@@ -55,12 +56,12 @@ class SpoiltAlcoholicProductTypeHelperSpec extends SpecBase {
       }
     }
 
-    "radioOptions" - {
-      "create radio options in view order for a set of regimes" in new SetUp {
-        val radioOptions =
-          spoiltAlcoholicProductTypeHelper.radioOptions(AlcoholRegimes(Set(Cider, OtherFermentedProduct, Beer)))
+    "getViewModel" - {
+      "create a view model containing radio options in view order for a set of regimes" in new SetUp {
+        val viewModel: SpoiltAlcoholicProductTypeViewModel =
+          spoiltAlcoholicProductTypeHelper.getViewModel(AlcoholRegimes(Set(Cider, OtherFermentedProduct, Beer)))
 
-        radioOptions mustBe Seq(
+        viewModel.radioOptions mustBe Seq(
           RadioItem(Text("Beer"), Some("Beer"), Some("Beer")),
           RadioItem(Text("Cider"), Some("Cider"), Some("Cider")),
           RadioItem(
@@ -79,9 +80,9 @@ class SpoiltAlcoholicProductTypeHelperSpec extends SpecBase {
     val expectedRegimeToTaxType: Map[AlcoholRegime, String] =
       Map(Beer -> "356", Wine -> "333", Cider -> "357", Spirits -> "345", OtherFermentedProduct -> "324")
 
-    val expectedSpoiltRate                                  = BigDecimal(0.01)
-    val expectedRangeMinABV                                 = BigDecimal(0)
-    val expectedRangeMaxABV                                 = BigDecimal(100)
+    val expectedSpoiltRate: BigDecimal                      = BigDecimal(0.01)
+    val expectedRangeMinABV: BigDecimal                     = BigDecimal(0)
+    val expectedRangeMaxABV: BigDecimal                     = BigDecimal(100)
 
     val spoiltAlcoholicProductTypeHelper = new SpoiltAlcoholicProductTypeHelper(appConfig)
   }

--- a/test/controllers/adjustment/WhenDidYouPayDutyControllerSpec.scala
+++ b/test/controllers/adjustment/WhenDidYouPayDutyControllerSpec.scala
@@ -32,6 +32,7 @@ import play.api.mvc.Call
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.HttpResponse
 import views.html.adjustment.WhenDidYouPayDutyView
+import viewmodels.adjustment.{WhenDidYouPayDutyHelper, WhenDidYouPayDutyViewModel}
 
 import scala.concurrent.Future
 
@@ -70,8 +71,14 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
   "WhenDidYouPayDuty Controller" - {
 
     "must return OK and the correct view for a GET" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-      val application = applicationBuilder(userAnswers = Some(validEmptyUserAnswers)).build()
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
+
+      val application = applicationBuilder(userAnswers = Some(validEmptyUserAnswers))
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val appConfig = application.injector.instanceOf[FrontendAppConfig]
@@ -83,7 +90,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result)          mustEqual OK
-        contentAsString(result) mustEqual view(form, NormalMode, adjustmentType, appConfig.exciseEnquiriesUrl)(
+        contentAsString(result) mustEqual view(
+          form,
+          NormalMode,
+          WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl)
+        )(
           request,
           getMessages(application)
         ).toString
@@ -91,8 +102,14 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     }
 
     "must populate the view correctly on a GET when the question has previously been answered" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-      val application = applicationBuilder(userAnswers = Some(userAnswers)).build()
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
+
+      val application = applicationBuilder(userAnswers = Some(userAnswers))
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val appConfig = application.injector.instanceOf[FrontendAppConfig]
@@ -107,8 +124,7 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
         contentAsString(result) mustEqual view(
           form.fill(validPeriod),
           NormalMode,
-          adjustmentType,
-          appConfig.exciseEnquiriesUrl
+          WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl)
         )(
           request,
           getMessages(application)
@@ -119,15 +135,19 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     "must redirect to the next page when valid data is submitted" in {
       val mockUserAnswersConnector = mock[UserAnswersConnector]
       val mockAdjustmentNavigator  = mock[AdjustmentNavigator]
+      val mockHelper               = mock[WhenDidYouPayDutyHelper]
 
       when(mockUserAnswersConnector.set(any())(any())) thenReturn Future.successful(mock[HttpResponse])
       when(mockAdjustmentNavigator.nextPage(eqTo(WhenDidYouPayDutyPage), any(), any(), any())) thenReturn onwardRoute
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
 
       val application =
         applicationBuilder(userAnswers = Some(validEmptyUserAnswers))
           .overrides(
             bind[AdjustmentNavigator].toInstance(mockAdjustmentNavigator),
-            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector)
+            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector),
+            bind[WhenDidYouPayDutyHelper].toInstance(mockHelper)
           )
           .build()
 
@@ -154,15 +174,19 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
 
       val mockUserAnswersConnector = mock[UserAnswersConnector]
       val mockAdjustmentNavigator  = mock[AdjustmentNavigator]
+      val mockHelper               = mock[WhenDidYouPayDutyHelper]
 
       when(mockUserAnswersConnector.set(any())(any())) thenReturn Future.successful(mock[HttpResponse])
       when(mockAdjustmentNavigator.nextPage(eqTo(WhenDidYouPayDutyPage), any(), any(), any())) thenReturn onwardRoute
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
 
       val application =
         applicationBuilder(userAnswers = Some(emptyUserAnswers))
           .overrides(
             bind[AdjustmentNavigator].toInstance(mockAdjustmentNavigator),
-            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector)
+            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector),
+            bind[WhenDidYouPayDutyHelper].toInstance(mockHelper)
           )
           .build()
 
@@ -200,15 +224,19 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
 
       val mockUserAnswersConnector = mock[UserAnswersConnector]
       val mockAdjustmentNavigator  = mock[AdjustmentNavigator]
+      val mockHelper               = mock[WhenDidYouPayDutyHelper]
 
       when(mockUserAnswersConnector.set(any())(any())) thenReturn Future.successful(mock[HttpResponse])
       when(mockAdjustmentNavigator.nextPage(eqTo(WhenDidYouPayDutyPage), any(), any(), any())) thenReturn onwardRoute
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
 
       val application =
         applicationBuilder(userAnswers = Some(userAnswers))
           .overrides(
             bind[AdjustmentNavigator].toInstance(mockAdjustmentNavigator),
-            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector)
+            bind[UserAnswersConnector].toInstance(mockUserAnswersConnector),
+            bind[WhenDidYouPayDutyHelper].toInstance(mockHelper)
           )
           .build()
 
@@ -232,8 +260,13 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     }
 
     "must return a Bad Request and errors when invalid data is submitted" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
+      when(mockHelper.createViewModel(any()))
+        .thenReturn(WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl))
 
-      val application = applicationBuilder(userAnswers = Some(validEmptyUserAnswers)).build()
+      val application = applicationBuilder(userAnswers = Some(validEmptyUserAnswers))
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val appConfig = application.injector.instanceOf[FrontendAppConfig]
@@ -249,7 +282,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
         val result = route(application, request).value
 
         status(result)          mustEqual BAD_REQUEST
-        contentAsString(result) mustEqual view(boundForm, NormalMode, adjustmentType, appConfig.exciseEnquiriesUrl)(
+        contentAsString(result) mustEqual view(
+          boundForm,
+          NormalMode,
+          WhenDidYouPayDutyViewModel(adjustmentType, appConfig.exciseEnquiriesUrl)
+        )(
           request,
           getMessages(application)
         ).toString
@@ -257,8 +294,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     }
 
     "must redirect to Journey Recovery for a GET if no existing data is found" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-      val application = applicationBuilder(userAnswers = None).build()
+      val application = applicationBuilder(userAnswers = None)
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val request = FakeRequest(GET, whenDidYouPayDutyRoute)
@@ -271,8 +311,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     }
 
     "must redirect to Journey Recovery for a GET if userAnswers are empty" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val request = FakeRequest(GET, whenDidYouPayDutyRoute)
@@ -285,8 +328,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
     }
 
     "must redirect to Journey Recovery for a POST if no existing data is found" in {
+      val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-      val application = applicationBuilder(userAnswers = None).build()
+      val application = applicationBuilder(userAnswers = None)
+        .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+        .build()
 
       running(application) {
         val request =
@@ -302,8 +348,11 @@ class WhenDidYouPayDutyControllerSpec extends SpecBase {
   }
 
   "must redirect to Journey Recovery for a POST with invalid data and empty user answers" in {
+    val mockHelper = mock[WhenDidYouPayDutyHelper]
 
-    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+    val application = applicationBuilder(userAnswers = Some(emptyUserAnswers))
+      .overrides(bind[WhenDidYouPayDutyHelper].toInstance(mockHelper))
+      .build()
 
     running(application) {
       val request =

--- a/test/models/adjustment/AdjustmentTypeSpec.scala
+++ b/test/models/adjustment/AdjustmentTypeSpec.scala
@@ -57,11 +57,11 @@ class AdjustmentTypeSpec extends AnyFreeSpec with Matchers with ScalaCheckProper
       }
     }
 
-    "getErrorLinkOverride must" - {
+    "getTopRadioId must" - {
       "get the override link when a value in the list is present" in {
         val mockMessages = mock[Messages]
 
-        AdjustmentType.getErrorLinkOverride(mockMessages) mustBe "spoilt"
+        AdjustmentType.getTopRadioId(mockMessages) mustBe "spoilt"
       }
     }
   }

--- a/test/models/adjustment/AdjustmentTypeSpec.scala
+++ b/test/models/adjustment/AdjustmentTypeSpec.scala
@@ -18,10 +18,12 @@ package models.adjustment
 
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.OptionValues
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.must.Matchers
-import org.scalatest.OptionValues
+import org.scalatestplus.mockito.MockitoSugar.mock
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import play.api.i18n.Messages
 import play.api.libs.json.{JsError, JsString, Json}
 
 class AdjustmentTypeSpec extends AnyFreeSpec with Matchers with ScalaCheckPropertyChecks with OptionValues {
@@ -30,7 +32,7 @@ class AdjustmentTypeSpec extends AnyFreeSpec with Matchers with ScalaCheckProper
 
     "must deserialise valid values" in {
 
-      val gen = Gen.oneOf(AdjustmentType.values.toSeq)
+      val gen = Gen.oneOf(AdjustmentType.values)
 
       forAll(gen) { adjustmentType =>
         JsString(adjustmentType.toString).validate[AdjustmentType].asOpt.value mustEqual adjustmentType
@@ -48,10 +50,18 @@ class AdjustmentTypeSpec extends AnyFreeSpec with Matchers with ScalaCheckProper
 
     "must serialise" in {
 
-      val gen = Gen.oneOf(AdjustmentType.values.toSeq)
+      val gen = Gen.oneOf(AdjustmentType.values)
 
       forAll(gen) { adjustmentType =>
         Json.toJson(adjustmentType) mustEqual JsString(adjustmentType.toString)
+      }
+    }
+
+    "getErrorLinkOverride must" - {
+      "get the override link when a value in the list is present" in {
+        val mockMessages = mock[Messages]
+
+        AdjustmentType.getErrorLinkOverride(mockMessages) mustBe "spoilt"
       }
     }
   }

--- a/test/viewmodels/PaginationViewModelSpec.scala
+++ b/test/viewmodels/PaginationViewModelSpec.scala
@@ -123,5 +123,18 @@ class PaginationViewModelSpec extends SpecBase {
         )
       )
     }
+
+    ".isMoreThanOnePage should" - {
+      "return true when the PaginationViewModel has more than one page" in {
+        val paginationViewModel = PaginationViewModel(2, 2, createUrl)
+
+        paginationViewModel.isMoreThanOnePage mustBe true
+      }
+      "return false when the PaginationViewModel has one page" in {
+        val paginationViewModel = PaginationViewModel(1, 1, createUrl)
+
+        paginationViewModel.isMoreThanOnePage mustBe false
+      }
+    }
   }
 }

--- a/test/viewmodels/adjustment/WhenDidYouPayDutyHelperSpec.scala
+++ b/test/viewmodels/adjustment/WhenDidYouPayDutyHelperSpec.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.adjustment
+
+import base.SpecBase
+import models.adjustment.AdjustmentType
+import models.adjustment.AdjustmentType.Overdeclaration
+
+class WhenDidYouPayDutyHelperSpec extends SpecBase {
+
+  "WhenDidYouPayDutyHelper" - {
+    "createViewModel method should create a view model with the declared adjustment type and correct url" in new Setup {
+      val testAdjustmentType: AdjustmentType = Overdeclaration
+
+      testHelper.createViewModel(testAdjustmentType) mustBe WhenDidYouPayDutyViewModel(
+        Overdeclaration,
+        appConfig.exciseEnquiriesUrl
+      )
+    }
+  }
+
+  class Setup {
+
+    val testHelper = app.injector.instanceOf[WhenDidYouPayDutyHelper]
+
+  }
+
+}

--- a/test/viewmodels/adjustment/WhenDidYouPayDutyViewModelSpec.scala
+++ b/test/viewmodels/adjustment/WhenDidYouPayDutyViewModelSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.adjustment
+
+import base.SpecBase
+import models.adjustment.AdjustmentType.{RepackagedDraughtProducts, Spoilt, Underdeclaration}
+import play.api.i18n.Messages
+
+class WhenDidYouPayDutyViewModelSpec extends SpecBase {
+
+  val url: String                 = appConfig.exciseEnquiriesUrl
+  implicit val messages: Messages = getMessages(app)
+
+  "WhenDidYouPayDutyViewModel getHeading method should" - {
+    "return the correct heading for an Under Declaration" in {
+      val viewModel = WhenDidYouPayDutyViewModel(Underdeclaration, url)
+
+      viewModel.getHeading mustBe messages("whenDidYouPayDuty.under-declaration.title")
+    }
+    "return the default heading for adjustment types that are not Spoilt ot Under Declaration" in {
+      val viewModel = WhenDidYouPayDutyViewModel(RepackagedDraughtProducts, url)
+
+      viewModel.getHeading mustBe messages("whenDidYouPayDuty.default.title")
+    }
+    "throw an exception if called on Spoilt" in {
+      val viewModel = WhenDidYouPayDutyViewModel(Spoilt, url)
+
+      assertThrows[IllegalArgumentException](viewModel.getHeading)
+    }
+  }
+
+}

--- a/test/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnViewModelSpec.scala
+++ b/test/viewmodels/checkAnswers/checkAndSubmit/DutyDueForThisReturnViewModelSpec.scala
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package viewmodels.checkAnswers.checkAndSubmit
+
+import base.SpecBase
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.Aliases.SummaryList
+
+class DutyDueForThisReturnViewModelSpec extends SpecBase {
+
+  val emptySummaryList            = SummaryList()
+  implicit val messages: Messages = getMessages(app)
+
+  "DutyDueForThisReturnViewModel" - {
+    "getTitle should get the nil version of the title when total is zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 0)
+
+      testViewModel.getTitle mustBe messages("dutyDueForThisReturn.nil.title")
+    }
+
+    "getTitle should get the normal version of the title when total is above zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 1)
+
+      testViewModel.getTitle mustBe messages("dutyDueForThisReturn.title", messages("site.currency.2DP", 1))
+    }
+
+    "getTitle should get the normal version of the title when total is below zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = -1)
+
+      testViewModel.getTitle mustBe messages("dutyDueForThisReturn.title", messages("site.currency.2DP", -1))
+    }
+  }
+
+  "isTotalDueZero" - {
+    "should return true when the total due is 0" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 0)
+
+      testViewModel.isTotalDueZero mustBe true
+    }
+
+    "should return false when the total due is not zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 3)
+
+      testViewModel.isTotalDueZero mustBe false
+    }
+  }
+
+  "isTotalDueAboveZero" - {
+    "should return true when the total due is above zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 1)
+
+      testViewModel.isTotalDueAboveZero mustBe true
+    }
+
+    "should return false when the total due is zero or less" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 0)
+
+      testViewModel.isTotalDueAboveZero mustBe false
+    }
+  }
+
+  "isTotalDueBelowZero" - {
+    "should return true when the total due is below zero" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = -1)
+
+      testViewModel.isTotalDueBelowZero mustBe true
+    }
+
+    "should return false when the total due is zero or more" in {
+      val testViewModel = DutyDueForThisReturnViewModel(emptySummaryList, emptySummaryList, totalDue = 0)
+
+      testViewModel.isTotalDueBelowZero mustBe false
+    }
+  }
+
+}


### PR DESCRIPTION
This is a PR for the ticket [ADR-1965](https://jira.tools.tax.service.gov.uk/browse/ADR-1965) Live Service Checklist - Investigate Returns FE use of logic in views.

I am searching for logic in the view that I can move to view models or controllers. This is good because logic in view files is an anti-pattern since the logic is not as well tested as other parts of the code.