### PR TITLE
ADR-2119 Create 'Declaring your wine for duty' guidance page

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -73,6 +73,7 @@ class FrontendAppConfig @Inject() (configuration: Configuration, servicesConfig:
   val requestAccessUrl: String              = configuration.get[String]("urls.requestAccess")
   val exciseEnquiriesUrl: String            = configuration.get[String]("urls.exciseEnquiries")
   val declareSpiritsGuidanceUrl: String     = configuration.get[String]("urls.declareSpiritsGuidance")
+  val alcoholicStrengthGuidanceUrl: String  = configuration.get[String]("urls.alcoholicStrengthGuidance")
   val userResearchSurveyUrl: String         = configuration.get[String]("urls.userResearchSurveyUrl")
   val userResearchSurveyUrlWelsh: String    = configuration.get[String]("urls.userResearchSurveyUrlWelsh")
 

--- a/app/controllers/declareDuty/DeclaringWineDutyGuidanceController.scala
+++ b/app/controllers/declareDuty/DeclaringWineDutyGuidanceController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declareDuty
+
+import config.FrontendAppConfig
+import controllers.actions._
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.declareDuty.DeclaringWineDutyGuidanceView
+
+import javax.inject.Inject
+
+class DeclaringWineDutyGuidanceController @Inject() (
+  override val messagesApi: MessagesApi,
+  identify: IdentifyWithEnrolmentAction,
+  getData: DataRetrievalAction,
+  requireData: DataRequiredAction,
+  appConfig: FrontendAppConfig,
+  val controllerComponents: MessagesControllerComponents,
+  view: DeclaringWineDutyGuidanceView
+) extends FrontendBaseController
+    with I18nSupport {
+
+  def onPageLoad(): Action[AnyContent] = (identify andThen getData andThen requireData) { implicit request =>
+    Ok(view(appConfig.alcoholicStrengthGuidanceUrl))
+  }
+}

--- a/app/viewmodels/tasklist/ReturnTaskListCreator.scala
+++ b/app/viewmodels/tasklist/ReturnTaskListCreator.scala
@@ -18,6 +18,7 @@ package viewmodels.tasklist
 
 import config.Constants
 import config.Constants.Css.marginBottom8CssClass
+import models.AlcoholRegime.Wine
 import models.TaskListSection.{AdjustmentSection, DutySuspendedSection, SpiritsSection}
 import models.adjustment.AdjustmentType
 import models.{AlcoholRegime, AlcoholRegimes, CheckMode, Mode, NormalMode, SpiritType, TaskListSection, UserAnswers}
@@ -135,15 +136,21 @@ class ReturnTaskListCreator @Inject() {
             TaskListItem(
               title = TaskListItemTitle(content = Text(messages(s"taskList.section.returns.$regime"))),
               status = AlcoholDutyTaskListItemStatus.inProgress,
-              href =
+              href = if (regime == Wine) {
+                Some(controllers.declareDuty.routes.DeclaringWineDutyGuidanceController.onPageLoad().url)
+              } else {
                 Some(controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, regime).url)
+              }
             )
           case _               =>
             TaskListItem(
               title = TaskListItemTitle(content = Text(messages(s"taskList.section.returns.$regime"))),
               status = AlcoholDutyTaskListItemStatus.notStarted,
-              href =
+              href = if (regime == Wine) {
+                Some(controllers.declareDuty.routes.DeclaringWineDutyGuidanceController.onPageLoad().url)
+              } else {
                 Some(controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, regime).url)
+              }
             )
         }
       )

--- a/app/views/declareDuty/DeclaringWineDutyGuidanceView.scala.html
+++ b/app/views/declareDuty/DeclaringWineDutyGuidanceView.scala.html
@@ -1,0 +1,89 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import components.{BulletList, Caption, Link, NumberedList, PageHeading, Paragraph, ReturnToTaskList, SectionBreak, SubHeading}
+@import config.Constants.Css
+@import models.AlcoholRegime.Wine
+
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton,
+        govukDetails: GovukDetails,
+        caption: Caption,
+        pageHeading: PageHeading,
+        subHeading: SubHeading,
+        paragraph: Paragraph,
+        link: Link,
+        bulletList: BulletList,
+        numberedList: NumberedList,
+        sectionBreak: SectionBreak,
+        returnToTaskList: ReturnToTaskList
+)
+
+@(alcoholicStrengthGuidanceUrl: String)(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("declaringWineDuty.title"))) {
+    @caption(
+        id = "declaring-wine-duty-guidance-section",
+        text = messages("section.return.Wine"),
+    )
+
+    @pageHeading(messages("declaringWineDuty.heading"))
+
+    @paragraph(messages("declaringWineDuty.p1"))
+
+    @subHeading(messages("declaringWineDuty.subHeading1"), classes = Css.headingMCssClass)
+
+    @paragraph(content = HtmlContent(
+        link(
+            id = "alcoholic-strength-guidance-link",
+            text = messages("declaringWineDuty.alcoholicStrength.link"),
+            href = alcoholicStrengthGuidanceUrl,
+            newTab = true
+        ) + "."
+    ))
+
+    @paragraph(messages("declaringWineDuty.p2"))
+    @bulletList(Seq(
+        messages("declareAlcoholDutyQuestion.p1.l1"),
+        messages("declareAlcoholDutyQuestion.p1.l2"),
+        messages("declareAlcoholDutyQuestion.p1.l3"),
+        messages("declareAlcoholDutyQuestion.p1.l4")
+    ))
+
+    @subHeading(messages("declaringWineDuty.subHeading2"), classes = Css.headingMCssClass)
+
+    @paragraph(messages("declaringWineDuty.p3"))
+
+    @govukDetails(Details(
+        summary = messages("declaringWineDuty.details.summary"),
+        content = HtmlContent(
+            paragraph(messages("declaringWineDuty.details.p")) +
+            numberedList(Seq(
+                messages("declaringWineDuty.details.calculation1"),
+                messages("declaringWineDuty.details.calculation2")
+            )).toString
+        )
+    ))
+
+    @sectionBreak()
+
+    @govukButton(
+        ButtonViewModel("continueButton", messages("site.continue"))
+        .asLink(controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, Wine).url)
+    )
+    @returnToTaskList()
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -57,6 +57,8 @@ POST       /complete-return/alcoholic-products/alcoholic-products-to-include    
 GET        /complete-return/alcoholic-products/change-alcoholic-products-to-include                  controllers.declareDuty.AlcoholTypeController.onPageLoad(mode: Mode = CheckMode)
 POST       /complete-return/alcoholic-products/change-alcoholic-products-to-include                  controllers.declareDuty.AlcoholTypeController.onSubmit(mode: Mode = CheckMode)
 
+GET        /complete-return/alcoholic-products/Wine/declaring-wine-duty                   controllers.declareDuty.DeclaringWineDutyGuidanceController.onPageLoad()
+
 GET        /complete-return/alcoholic-products/:regime/declare/products-to-include                controllers.declareDuty.WhatDoYouNeedToDeclareController.onPageLoad(mode: Mode = NormalMode, regime: AlcoholRegime)
 POST       /complete-return/alcoholic-products/:regime/declare/products-to-include                controllers.declareDuty.WhatDoYouNeedToDeclareController.onSubmit(mode: Mode = NormalMode, regime: AlcoholRegime)
 GET        /complete-return/alcoholic-products/:regime/change/products-to-include         controllers.declareDuty.WhatDoYouNeedToDeclareController.onPageLoad(mode: Mode = CheckMode, regime: AlcoholRegime)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -109,6 +109,7 @@ urls {
   feedbackFrontendBase         = "http://localhost:9514"
   exciseEnquiries              = "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/excise-enquiries"
   declareSpiritsGuidance       = "https://www.gov.uk/hmrc-internal-manuals/spirits-production/spir4100"
+  alcoholicStrengthGuidance    = "https://www.gov.uk/guidance/alcoholic-products-technical-guide/section-11-alcoholic-strength"
   userResearchSurveyUrl        = "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Manage_Alcohol_Duty_Complete_Return_Return_Sent"
   userResearchSurveyUrlWelsh   = "https://survey.take-part-in-research.service.gov.uk/jfe/form/SV_74GjifgnGv6GsMC?Source=BannerList_HMRC_Manage_Alcohol_Duty_Complete_Return_Return_Sent_Welsh&Q_Language=CY"
 }

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -398,6 +398,19 @@ declareAlcoholDutyQuestion.cider.p2.l2 = seidr pefriog rhwng 5.6% ac 8.4%
 declareAlcoholDutyQuestion.h4 = A oes angen i chi ddatgan unrhyw gynhyrchion alcoholaidd?
 declareAlcoholDutyQuestion.error.required = Dewiswch ‘Iawn’ os oes angen i chi ddatgan unrhyw gynhyrchion alcoholaidd
 
+declaringWineDuty.title = Datgan eich gwin am doll
+declaringWineDuty.heading = Datgan eich gwin am doll
+declaringWineDuty.p1 = Mae angen i ni wybod faint o win rydych chi wedi’i gynhyrchu a’r litrau o alcohol pur y mae’n ei gynnwys yn seiliedig ar ei fand alcohol yn ôl cyfaint (ABV).
+declaringWineDuty.subHeading1 = Mae’n rhaid i chi ddatgan eich cynhyrchion gwin yn ôl eu cryfder ABV
+declaringWineDuty.alcoholicStrength.link = Dysgwch ragor am yr hyn y mae cryfder alcoholaidd yn ei olygu wrth ddatgan eich toll (yn agor tab newydd)
+declaringWineDuty.p2 = Mae’n rhaid i chi nawr ddatgan eich gwin o dan un o’r bandiau ABV:
+declaringWineDuty.subHeading2 = Cyfrifo’ch litrau o alcohol pur
+declaringWineDuty.p3 = I gyfrifo’r litrau o alcohol pur, lluoswch y cyfanswm o win mewn litrau â chryfder yr ABV, yna rhannwch â 100.
+declaringWineDuty.details.summary = Enghraifft o gyfrifiad
+declaringWineDuty.details.p = Mae gennych 4,297.55 litr o win ar 13.5% ABV. I gyfrifo’r litrau o alcohol pur yn y gwin hwn, mae’n rhaid i chi wneud y canlynol:
+declaringWineDuty.details.calculation1 = 4,297.55 litr x 13.5% ABV = 58,016.925
+declaringWineDuty.details.calculation2 = 58,016.925 ÷ 100 = 580.1692 litr o alcohol pur
+
 whatDoYouNeedToDeclare.title = Beth y mae angen i chi ei ddatgan?
 whatDoYouNeedToDeclare.heading = Beth y mae angen i chi ei ddatgan?
 whatDoYouNeedToDeclare.hint = Dewiswch bob un sy’n berthnasol

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -398,6 +398,19 @@ declareAlcoholDutyQuestion.cider.p2.l2 = sparkling cider between 5.6% and 8.4%
 declareAlcoholDutyQuestion.h4 = Do you need to declare any alcoholic products?
 declareAlcoholDutyQuestion.error.required = Select yes if you need to declare any alcoholic products
 
+declaringWineDuty.title = Declaring your wine for duty
+declaringWineDuty.heading = Declaring your wine for duty
+declaringWineDuty.p1 = We need to know how much wine you’ve produced and the litres of pure alcohol it contains based on its alcohol by volume (ABV) band.
+declaringWineDuty.subHeading1 = You must declare your wine products according to their ABV strength
+declaringWineDuty.alcoholicStrength.link = Find out more about what alcoholic strength means when declaring your duty (opens in a new tab)
+declaringWineDuty.p2 = You must now declare your wine under one of the ABV bands:
+declaringWineDuty.subHeading2 = Calculating your litres of pure alcohol
+declaringWineDuty.p3 = To calculate the litres of pure alcohol, multiply the total volume of wine in litres by the ABV strength, then divide by 100.
+declaringWineDuty.details.summary = Example of a calculation
+declaringWineDuty.details.p = You have 4,297.55 litres of wine at 13.5% ABV. To calculate the litres of pure alcohol in this wine, you must:
+declaringWineDuty.details.calculation1 = 4,297.55 litres x 13.5% ABV = 58,016.925
+declaringWineDuty.details.calculation2 = 58,016.925 ÷ 100 = 580.1692 litres of pure alcohol
+
 whatDoYouNeedToDeclare.title = What do you need to declare?
 whatDoYouNeedToDeclare.heading = What do you need to declare?
 whatDoYouNeedToDeclare.hint = Select all that apply

--- a/test/controllers/declareDuty/DeclaringWineDutyGuidanceControllerSpec.scala
+++ b/test/controllers/declareDuty/DeclaringWineDutyGuidanceControllerSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declareDuty
+
+import base.SpecBase
+import play.api.test.Helpers._
+import views.html.declareDuty.DeclaringWineDutyGuidanceView
+
+class DeclaringWineDutyGuidanceControllerSpec extends SpecBase {
+
+  lazy val declaringWineDutyGuidanceRoute = routes.DeclaringWineDutyGuidanceController.onPageLoad().url
+
+  "DeclaringWineDutyGuidance Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+      val application = applicationBuilder(userAnswers = Some(userAnswersWithWine)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, declaringWineDutyGuidanceRoute)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[DeclaringWineDutyGuidanceView]
+
+        status(result)          mustEqual OK
+        contentAsString(result) mustEqual view(appConfig.alcoholicStrengthGuidanceUrl)(
+          request,
+          getMessages(application)
+        ).toString
+      }
+    }
+
+    "must redirect to Journey Recovery for a GET if no existing data is found" in {
+      val application = applicationBuilder(userAnswers = None).build()
+
+      running(application) {
+        val request = FakeRequest(GET, declaringWineDutyGuidanceRoute)
+
+        val result = route(application, request).value
+
+        status(result)                 mustEqual SEE_OTHER
+        redirectLocation(result).value mustEqual controllers.routes.JourneyRecoveryController.onPageLoad().url
+      }
+    }
+  }
+}

--- a/test/viewmodels/tasklist/ReturnTaskListCreatorSpec.scala
+++ b/test/viewmodels/tasklist/ReturnTaskListCreatorSpec.scala
@@ -217,14 +217,18 @@ class ReturnTaskListCreatorSpec extends SpecBase {
             maybeTask.get.status mustBe AlcoholDutyTaskListItemStatus.notStarted
           }
 
-          s"the subtask for ${regime.entryName} must link to the what do you need to declare page for that regime" in {
+          s"the subtask for ${regime.entryName} must link to the first page of the journey for that regime" in {
             val maybeTask = result.taskList.items.find(
               _.title.content == Text(messages(s"taskList.section.returns.${regime.entryName}"))
             )
 
-            maybeTask.get.href mustBe Some(
+            val firstPageWithinRegimeUrl = if (regime == Wine) {
+              controllers.declareDuty.routes.DeclaringWineDutyGuidanceController.onPageLoad().url
+            } else {
               controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, regime).url
-            )
+            }
+
+            maybeTask.get.href mustBe Some(firstPageWithinRegimeUrl)
           }
         }
 
@@ -287,14 +291,18 @@ class ReturnTaskListCreatorSpec extends SpecBase {
               maybeTask.get.status mustBe AlcoholDutyTaskListItemStatus.notStarted
             }
 
-            s"the sub task for ${regime.entryName} must link to the what do you need to declare page for that regime" in {
+            s"the sub task for ${regime.entryName} must link to the first page of the journey for that regime" in {
               val maybeTask = result.taskList.items.find(
                 _.title.content == Text(messages(s"taskList.section.returns.${regime.entryName}"))
               )
 
-              maybeTask.get.href mustBe Some(
+              val firstPageWithinRegimeUrl = if (regime == Wine) {
+                controllers.declareDuty.routes.DeclaringWineDutyGuidanceController.onPageLoad().url
+              } else {
                 controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, regime).url
-              )
+              }
+
+              maybeTask.get.href mustBe Some(firstPageWithinRegimeUrl)
             }
 
             "no hint must be displayed" in {
@@ -362,14 +370,18 @@ class ReturnTaskListCreatorSpec extends SpecBase {
               maybeTask.get.status mustBe AlcoholDutyTaskListItemStatus.inProgress
             }
 
-            s"the sub task for ${regime.entryName} must link to the what do you need to declare page for that regime" in {
+            s"the sub task for ${regime.entryName} must link to the first page of the journey for that regime" in {
               val maybeTask = result.taskList.items.find(
                 _.title.content == Text(messages(s"taskList.section.returns.${regime.entryName}"))
               )
 
-              maybeTask.get.href mustBe Some(
+              val firstPageWithinRegimeUrl = if (regime == Wine) {
+                controllers.declareDuty.routes.DeclaringWineDutyGuidanceController.onPageLoad().url
+              } else {
                 controllers.declareDuty.routes.WhatDoYouNeedToDeclareController.onPageLoad(NormalMode, regime).url
-              )
+              }
+
+              maybeTask.get.href mustBe Some(firstPageWithinRegimeUrl)
             }
 
             "no hint must be displayed" in {


### PR DESCRIPTION
The new page is the first page of the wine journey and does not have a form. It does not have to be factored into the navigator, which handles subsequent pages based on data saved to user answers, but the 'Declare wine' link on the task list has to be edited.